### PR TITLE
fix typo: usefull -> useful

### DIFF
--- a/README
+++ b/README
@@ -117,7 +117,7 @@ The command line parameters for par2cmdline are as follow:
     -q [-q]  : Be more quiet (-qq gives silence)
     -p       : Purge backup files and par files on successful recovery or
                when no recovery is needed
-    -R       : Recurse into subdirectories (only usefull on create)
+    -R       : Recurse into subdirectories (only useful on create)
     --       : Treat all remaining CommandLine as filenames
 
 If you wish to create par2 files for a single source file, you may leave

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The command line parameters for par2cmdline are as follow:
     -q [-q]  : Be more quiet (-qq gives silence)
     -p       : Purge backup files and par files on successful recovery or
                when no recovery is needed
-    -R       : Recurse into subdirectories (only usefull on create)
+    -R       : Recurse into subdirectories (only useful on create)
     --       : Treat all remaining CommandLine as filenames
 
 If you wish to create par2 files for a single source file, you may leave out the name of the par2 file from the command line. par2cmdline will then assume that you wish to base the filenames for the par2 files on the name of the source file.

--- a/commandline.cpp
+++ b/commandline.cpp
@@ -129,7 +129,7 @@ void CommandLine::usage(void)
     "  -q [-q]  : Be more quiet (-q -q gives silence)\n"
     "  -p       : Purge backup files and par files on successful recovery or\n"
     "             when no recovery is needed\n"
-    "  -R       : Recurse into subdirectories (only usefull on create)\n"
+    "  -R       : Recurse into subdirectories (only useful on create)\n"
     "  --       : Treat all remaining CommandLine as filenames\n"
     "\n";
 }

--- a/par2.1
+++ b/par2.1
@@ -60,7 +60,7 @@ par2repair [options] <par2 file> [files]
 .br
            when no recovery is needed
 .br
--R       : Recurse into subdirectories (only usefull on create)
+-R       : Recurse into subdirectories (only useful on create)
 .br
 --       : Treat all remaining CommandLine as filenames
 .SH AUTHORS


### PR DESCRIPTION
fix a simple typo that triggers a lintian warning in debian
