### PR TITLE
fix compilation with certain versions of gcc

### DIFF
--- a/diskfile.cpp
+++ b/diskfile.cpp
@@ -18,6 +18,7 @@
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "par2cmdline.h"
+#include <limits.h>
 
 #ifdef _MSC_VER
 #ifdef _DEBUG


### PR DESCRIPTION
On FreeBSD at least, with GCC 4.7, par2cmdline fails to compile, complaining about PATH_MAX.

Including <limits.h> fixes this
