### PR TITLE
par2creator: use proper buffer size for volume file name generation

### DIFF
--- a/par2creator.cpp
+++ b/par2creator.cpp
@@ -698,7 +698,7 @@ bool Par2Creator::InitialiseOutputFiles(string par2filename)
     fileallocations[recoveryfilecount].count = 0;
 
     // Determine the format to use for filenames of recovery files
-    char filenameformat[300];
+    char filenameformat[_MAX_PATH];
     {
       u32 limitLow = 0;
       u32 limitCount = 0;
@@ -732,7 +732,7 @@ bool Par2Creator::InitialiseOutputFiles(string par2filename)
     // Set the filenames
     for (u32 filenumber=0; filenumber<recoveryfilecount; filenumber++)
     {
-      char filename[300];
+      char filename[_MAX_PATH];
       snprintf(filename, sizeof(filename), filenameformat, par2filename.c_str(), fileallocations[filenumber].exponent, fileallocations[filenumber].count);
       fileallocations[filenumber].filename = filename;
     }


### PR DESCRIPTION
If the complete path to the vol*.par2-files exeeds 300 bytes, the path
is silently truncated.

Use `_MAX_PATH` define for proper buffer size.

Signed-off-by: Philipp Zimmer <pz@ggdns.de>