### PR TITLE
Fix issue #53 / Correct fix for issue #49

### DIFF
--- a/par2repairer.cpp
+++ b/par2repairer.cpp
@@ -1141,15 +1141,16 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::list<Comm
     // What filename does the file use
     const std::string& file = sourcefile->TargetFileName();
     const std::string& name = DiskFile::SplitRelativeFilename(file, basepath);
-
+    const std::string& target_pathname = DiskFile::GetCanonicalPathname(file);
+    
     // if the target file is in the list of extra files, we remove it
     // from the extra files.
     list<CommandLine::ExtraFile>::iterator it = extrafiles.begin();
     for (; it != extrafiles.end(); ++it)
     {
       const CommandLine::ExtraFile& e = *it;
-      const std::string& file = e.FileName();
-      if (file.find(name) != std::string::npos)
+      const std::string& extra_pathname = e.FileName();
+      if (!extra_pathname.compare(target_pathname))
       {
         extrafiles.erase(it);
         break;


### PR DESCRIPTION
The previous fix for issue #49 (Scanning extra files messes up verification) was supposed to ignore an extra file that is identical with the target file during the recovery process. But that fix caused the first extra file with a target file name (without path) matching a substring in the full path of the extra file name to be ignored during recovery attempts (issue #53). This fix discards the extra file only if the  'canonical' target path is identical with the 'canonical' extra file path. Notice that the return value of 'ExtraFile::FileName()' is already a canonical full path (see initialization of extra file list). Because all file names in the list of extra files are unique the search for a matching file name can be aborted after the first match.