### PR TITLE
Use /dev/urandom in test 20

### DIFF
--- a/tests/test20
+++ b/tests/test20
@@ -16,7 +16,7 @@ echo $dashes
 echo $banner
 echo $dashes
 
-dd bs=1000 count=2 iflag=fullblock if=/dev/random of=myfile.dat
+dd bs=1000 count=2 iflag=fullblock if=/dev/urandom of=myfile.dat
 
 banner="Creating PAR 2.0 recovery data"
 dashes=`echo "$banner" | sed s/./-/g`


### PR DESCRIPTION
The build process hangs for a long time while test 20 reads from /dev/random. On my desktop it eventually completed without error after more than half an hour, on a virtualbox vm it takes even longer. Using /dev/urandom instead prevents this delay.