### PR TITLE
Avoid unconditional use of PATH_MAX

### DIFF
--- a/diskfile.cpp
+++ b/diskfile.cpp
@@ -654,8 +654,14 @@ string DiskFile::GetCanonicalPathname(string filename)
     return filename;
 
   // Get the current directory
+#ifdef PATH_MAX
   char curdir[PATH_MAX];
   if (0 == getcwd(curdir, sizeof(curdir)))
+#else
+  // Avoid unconditional use of PATH_MAX (not defined on hurd)
+  char *curdir = get_current_dir_name();
+  if (curdir == NULL)
+#endif
   {
     return filename;
   }
@@ -664,6 +670,9 @@ string DiskFile::GetCanonicalPathname(string filename)
   // Allocate a work buffer and copy the resulting full path into it.
   char *work = new char[strlen(curdir) + filename.size() + 2];
   strcpy(work, curdir);
+#ifndef PATH_MAX
+  free(curdir);
+#endif
   if (work[strlen(work)-1] != '/')
     strcat(work, "/");
   strcat(work, filename.c_str());


### PR DESCRIPTION
PATH_MAX isn't defined on hurd, causing par2cmdline to fail to build [1]. Proposed code change works around that by trying get_current_dir_name() instead on such platforms.

[1] see https://buildd.debian.org/status/fetch.php?pkg=par2cmdline&arch=hurd-i386&ver=0.6.14-1&stamp=1439287555