### PR TITLE
Fix issue #55, on OpenBSD 5.6+ __BYTE_ORDER is not defined

### DIFF
--- a/par2cmdline.h
+++ b/par2cmdline.h
@@ -156,9 +156,9 @@ typedef unsigned long long u64;
 #  ifndef __LITTLE_ENDIAN
 #    ifdef _LITTLE_ENDIAN
 #      define __LITTLE_ENDIAN _LITTLE_ENDIAN
-#      define __LITTLE_ENDIAN _LITTLE_ENDIAN
 #      define __BIG_ENDIAN _BIG_ENDIAN
 #      define __PDP_ENDIAN _PDP_ENDIAN
+#      define __BYTE_ORDER _BYTE_ORDER
 #    else
 #      error <endian.h> does not define __LITTLE_ENDIAN etc.
 #    endif

--- a/reedsolomon.cpp
+++ b/reedsolomon.cpp
@@ -294,7 +294,7 @@ template<> bool ReedSolomon<Galois16>::InternalProcess(const Galois16 &factor, s
     *pL = *LL + *HL;
 #else
     unsigned int temp = *LL + *HL;
-    *pL = (temp >> 8) & 0xff | (temp << 8) & 0xff00;
+    *pL = ((temp >> 8) & 0xff) | ((temp << 8) & 0xff00);
 #endif
 
     pL++;
@@ -305,7 +305,7 @@ template<> bool ReedSolomon<Galois16>::InternalProcess(const Galois16 &factor, s
     *pH = *LH + *HH;
 #else
     temp = *LH + *HH;
-    *pH = (temp >> 8) & 0xff | (temp << 8) & 0xff00;
+    *pH = ((temp >> 8) & 0xff) | ((temp << 8) & 0xff00);
 #endif
 
     pH++;


### PR DESCRIPTION
- properly define __BYTE_ORDER
- remove double line, which defines __LITTLE_ENDIAN
- on gcc 4.9.3 mute c++ warning: suggest parentheses around arithmetic in operand of '|' [-Wparentheses]