### PR TITLE
OpenBSD fixes for regress scripts

### DIFF
--- a/tests/test12
+++ b/tests/test12
@@ -19,7 +19,7 @@ echo $banner
 echo $dashes
 
 mv test.data test.data-correct
-head -c 113579 test.data-correct > test.data
+dd if=test.data-correct bs=113579 count=1 status=none of=test.data
 
 ../../par2 r test.par2 > ../$testname.log || { echo "ERROR: repair files using PAR 2.0 failed" ; exit 1; } >&2
 

--- a/tests/test13
+++ b/tests/test13
@@ -28,7 +28,7 @@ echo $banner
 echo $dashes
 
 mv test-1.data test-1.data-correct
-head -c 177173 test-1.data-correct > test-1.data
+dd if=test-1.data-correct bs=177173 count=1 status=none of=test-1.data
 
 ../../par2 r testdata.par2 > ../$testname.log || { echo "ERROR: repair files using PAR 2.0 failed" ; exit 1; } >&2
 

--- a/tests/test15
+++ b/tests/test15
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 cd tests || { echo "ERROR: Could not change to tests directory" ; exit 1; } >&2
-
 tests=../../$srcdir/tests
 
 testname=$(basename $0)

--- a/tests/test18
+++ b/tests/test18
@@ -28,7 +28,7 @@ echo $banner
 echo $dashes
 
 mv flatdata.tar.gz flatdata.tar.gz-orig
-head -c 1983 flatdata.tar.gz-orig > flatdata.tar.gz
+dd if=flatdata.tar.gz-orig bs=1983 count=1 status=none of=flatdata.tar.gz
 rm -f flatdata.tar.gz-orig
 
 ../../par2 r recovery.par2 ./* > ../$testname.log || { echo "ERROR: PAR 2.0 repair failed" ; exit 1; } >&2

--- a/tests/test20
+++ b/tests/test20
@@ -16,7 +16,7 @@ echo $dashes
 echo $banner
 echo $dashes
 
-dd bs=1000 count=2 iflag=fullblock if=/dev/urandom of=myfile.dat
+dd bs=1000 count=2 if=/dev/urandom of=myfile.dat
 
 banner="Creating PAR 2.0 recovery data"
 dashes=`echo "$banner" | sed s/./-/g`


### PR DESCRIPTION
- option -c to head(1) is not supported, use dd(1) instead
- option iflag to dd(1) is not supported, just drop it
- remove stray blank line

All regress tests pass on OpenBSD/amd64 5.8-current from Oct 2, 2015