### PR TITLE
Explicitly add -z option to tar(1) during extraction.

### DIFF
--- a/tests/test1
+++ b/tests/test1
@@ -9,8 +9,8 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
-tar -xf $tests/flatdata-par1files.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
+tar -xzf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/flatdata-par1files.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
 
 banner="Verifying using PAR 1.0 data"
 dashes=`echo "$banner" | sed s/./-/g`

--- a/tests/test10
+++ b/tests/test10
@@ -9,8 +9,8 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/smallsubdirdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
-tar -xf $tests/smallsubdirdata-par2files.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
+tar -xzf $tests/smallsubdirdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/smallsubdirdata-par2files.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
 
 banner="Repairing deleted subdir using PAR 2.0 data"
 dashes=`echo "$banner" | sed s/./-/g`

--- a/tests/test11
+++ b/tests/test11
@@ -9,7 +9,7 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/100blocks.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/100blocks.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
 
 banner="create par2files using 100 blocks"
 dashes=`echo "$banner" | sed s/./-/g`

--- a/tests/test12
+++ b/tests/test12
@@ -9,7 +9,7 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/readbeyondeof.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/readbeyondeof.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
 
 banner="repair files where the filesize got changed"
 dashes=`echo "$banner" | sed s/./-/g`

--- a/tests/test13
+++ b/tests/test13
@@ -9,7 +9,7 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
 
 banner="create 5% recovery files"
 dashes=`echo "$banner" | sed s/./-/g`

--- a/tests/test14
+++ b/tests/test14
@@ -9,7 +9,7 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
 
 banner="create 5% recovery files"
 dashes=`echo "$banner" | sed s/./-/g`

--- a/tests/test15
+++ b/tests/test15
@@ -9,7 +9,7 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/par2-0.6.8-crash.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/par2-0.6.8-crash.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
 
 banner="repair files should succeed, (issue #35)"
 dashes=`echo "$banner" | sed s/./-/g`

--- a/tests/test16
+++ b/tests/test16
@@ -9,7 +9,7 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
 
 banner="don't allow files outside par2 basedir, (issue #34, #36)"
 dashes=`echo "$banner" | sed s/./-/g`

--- a/tests/test17
+++ b/tests/test17
@@ -9,7 +9,7 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/bug44.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/bug44.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
 
 banner="remove subdir structure and repair, see #44"
 dashes=`echo "$banner" | sed s/./-/g`

--- a/tests/test2
+++ b/tests/test2
@@ -9,8 +9,8 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
-tar -xf $tests/flatdata-par2files.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
+tar -xzf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/flatdata-par2files.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
 
 banner="Verifying using PAR 2.0 data"
 dashes=`echo "$banner" | sed s/./-/g`

--- a/tests/test3
+++ b/tests/test3
@@ -9,8 +9,8 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
-tar -xf $tests/flatdata-par1files.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
+tar -xzf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/flatdata-par1files.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
 
 cp test-0.data test-0.data.orig
 cp test-1.data test-1.data.orig

--- a/tests/test4
+++ b/tests/test4
@@ -9,8 +9,8 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
-tar -xf $tests/flatdata-par2files.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
+tar -xzf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/flatdata-par2files.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
 
 cp test-0.data test-0.data.orig
 cp test-1.data test-1.data.orig

--- a/tests/test5
+++ b/tests/test5
@@ -9,7 +9,7 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
 
 banner="Creating 100% PAR 2.0 recovery data"
 dashes=`echo "$banner" | sed s/./-/g`

--- a/tests/test6
+++ b/tests/test6
@@ -9,8 +9,8 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/subdirdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
-tar -xf $tests/subdirdata-par2files-unix.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
+tar -xzf $tests/subdirdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/subdirdata-par2files-unix.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
 
 banner="Repairing two files in subdirs using PAR 2.0 data"
 dashes=`echo "$banner" | sed s/./-/g`

--- a/tests/test7
+++ b/tests/test7
@@ -9,8 +9,8 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/subdirdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
-tar -xf $tests/subdirdata-par2files-win.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
+tar -xzf $tests/subdirdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/subdirdata-par2files-win.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
 
 banner="Repairing two files in subdirs using PAR 2.0 data generated on windows"
 dashes=`echo "$banner" | sed s/./-/g`

--- a/tests/test8
+++ b/tests/test8
@@ -9,7 +9,7 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/subdirdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/subdirdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
 
 mkdir source1 && mv subdir1 subdir2 source1
 

--- a/tests/test9
+++ b/tests/test9
@@ -9,8 +9,8 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
-tar -xf $tests/flatdata-par2files.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
+tar -xzf $tests/flatdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/flatdata-par2files.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
 
 banner="rename using PAR 2.0 data"
 dashes=`echo "$banner" | sed s/./-/g`

--- a/tests/testMem
+++ b/tests/testMem
@@ -9,8 +9,8 @@ rm -rf run$testname
 
 mkdir run$testname && cd run$testname || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
-tar -xf $tests/subdirdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
-tar -xf $tests/subdirdata-par2files-unix.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
+tar -xzf $tests/subdirdata.tar.gz || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+tar -xzf $tests/subdirdata-par2files-unix.tar.gz || { echo "ERROR: Could not extract par test files" ; exit 1; } >&2
 
 rm -f subdir1/test-2.data subdir2/test-7.data
 valgrind --tool=memcheck --leak-check=yes ../../par2 r testdata.par2


### PR DESCRIPTION
Not all tar implementations, will handle gzip'ed archives
automatically. This for example helps on OpenBSD.