### PR TITLE
invert -N behaviour, -N now enables skipping

### DIFF
--- a/README
+++ b/README
@@ -119,7 +119,7 @@ The command line parameters for par2cmdline are as follow:
     -p       : Purge backup files and par files on successful recovery or
                when no recovery is needed
     -R       : Recurse into subdirectories (only useful on create)
-    -N       : No data skipping (find badly misspositioned data blocks)
+    -N       : data skipping (find badly mispositioned data blocks)
     -S<n>    : Skip leaway (distance +/- from expected block position)
     -B<path> : Set the basepath to use as reference for the datafiles
     --       : Treat all remaining CommandLine as filenames

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The command line parameters for par2cmdline are as follow:
     -p       : Purge backup files and par files on successful recovery or
                when no recovery is needed
     -R       : Recurse into subdirectories (only useful on create)
-    -N       : No data skipping (find badly misspositioned data blocks)
+    -N       : data skipping (find badly mispositioned data blocks)
     -S<n>    : Skip leaway (distance +/- from expected block position)
     -B<path> : Set the basepath to use as reference for the datafiles
     --       : Treat all remaining CommandLine as filenames

--- a/commandline.cpp
+++ b/commandline.cpp
@@ -75,7 +75,7 @@ CommandLine::CommandLine(void)
 , memorylimit(0)
 , purgefiles(false)
 , recursive(false)
-, skipdata(true)
+, skipdata(false)
 , skipleaway(0)
 {
 }
@@ -134,7 +134,7 @@ void CommandLine::usage(void)
     "  -p       : Purge backup files and par files on successful recovery or\n"
     "             when no recovery is needed\n"
     "  -R       : Recurse into subdirectories (only useful on create)\n"
-    "  -N       : No data skipping (find badly mispositioned data blocks)\n"
+    "  -N       : data skipping (find badly mispositioned data blocks)\n"
     "  -S<n>    : Skip leaway (distance +/- from expected block position)\n"
     "  -B<path> : Set the basepath to use as reference for the datafiles\n"
     "  --       : Treat all remaining CommandLine as filenames\n"
@@ -667,15 +667,10 @@ bool CommandLine::Parse(int argc, char *argv[])
           {
             if (operation == opCreate)
             {
-              cerr << "Cannot specify No Data Skipping unless reparing or verifying." << endl;
+              cerr << "Cannot specify Data Skipping unless reparing or verifying." << endl;
               return false;
             }
-            if (skipleaway > 0)
-            {
-              cerr << "Cannot specify no skipping and skip leaway." << endl;
-              return false;
-            }
-            skipdata = false;
+            skipdata = true;
           }
           break;
 

--- a/par2.1
+++ b/par2.1
@@ -88,7 +88,7 @@ Purge backup files and par files on successful recovery or when no recovery is n
 Recurse into subdirectories (only useful on create)
 .TP
 .B \-N
-No data skipping (find badly mispositioned data blocks)
+data skipping (find badly mispositioned data blocks)
 .TP
 .B \-S<n>
 Skip leaway (distance +/\- from expected block position)

--- a/tests/test19
+++ b/tests/test19
@@ -48,7 +48,7 @@ echo $dashes
 echo $banner
 echo $dashes
 
-../../par2 r -S99 -vv recovery.par2 >> $tests/$testname.log && { echo "ERROR: Repair should not be possible with skip leaway set to 99" ; exit 1; } >&2
+../../par2 r -N -S99 -vv recovery.par2 >> $tests/$testname.log && { echo "ERROR: Repair should not be possible with skip leaway set to 99" ; exit 1; } >&2
 ls -l
 
 banner="Repairing using PAR 2.0 data (with skip leaway 100 - should succeed)"
@@ -58,7 +58,7 @@ echo $dashes
 echo $banner
 echo $dashes
 
-../../par2 r -S100 -vv recovery.par2 >> $tests/$testname.log || { echo "ERROR: Repair should be possible with skip leaway set to 100" ; exit 1; } >&2
+../../par2 r -N -S100 -vv recovery.par2 >> $tests/$testname.log || { echo "ERROR: Repair should be possible with skip leaway set to 100" ; exit 1; } >&2
 ls -l
 
 cd ..


### PR DESCRIPTION
By default there is no skipping of data enabled now to avoid a possible
DOS where we get md5 collisions in a parchive. When you think there is
such a case you must now explicitly pass -N to skip blocks.

implements #65

Signed-off-by: BlackEagle <ike.devolder@gmail.com>