### PR TITLE
build-win* use -s flag for gcc then we don't need strip anymore, #94

### DIFF
--- a/build/build-win32.sh
+++ b/build/build-win32.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-export CFLAGS="-O3 -pipe -fstack-protector-strong"
-export CXXFLAGS="-O3 -pipe -fstack-protector-strong"
+export CFLAGS="-O3 -s -pipe -fstack-protector-strong"
+export CXXFLAGS="-O3 -s -pipe -fstack-protector-strong"
 export LDFLAGS="-static"
 
 # automake
@@ -10,5 +10,3 @@ export LDFLAGS="-static"
 ./configure --host=i686-w64-mingw32
 # make
 make
-# strip
-/usr/x86_64-w64-mingw32/bin/strip par2.exe

--- a/build/build-win64.sh
+++ b/build/build-win64.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-export CFLAGS="-O3 -pipe -fstack-protector-strong"
-export CXXFLAGS="-O3 -pipe -fstack-protector-strong"
+export CFLAGS="-O3 -s -pipe -fstack-protector-strong"
+export CXXFLAGS="-O3 -s -pipe -fstack-protector-strong"
 export LDFLAGS="-static"
 
 # automake
@@ -10,5 +10,3 @@ export LDFLAGS="-static"
 ./configure --host=x86_64-w64-mingw32
 # make
 make
-# strip
-/usr/x86_64-w64-mingw32/bin/strip par2.exe


### PR DESCRIPTION
Signed-off-by: BlackEagle <ike.devolder@gmail.com>