### PR TITLE
copy pasted to much in aliasing fix

### DIFF
--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -158,9 +158,9 @@ bool DiskFile::Write(u64 _offset, const void *buffer, size_t length)
 
   if (offset != _offset)
   {
-    LONG* ptrfilesize = (LONG*)&filesize;
-    LONG lowoffset = ptrfilesize[0];
-    LONG highoffset = ptrfilesize[1];
+    LONG* ptroffset = (LONG*)&_offset;
+    LONG lowoffset = ptroffset[0];
+    LONG highoffset = ptroffset[1];
 
     // Seek to the required offset
     if (INVALID_SET_FILE_POINTER == SetFilePointer(hFile, lowoffset, &highoffset, FILE_BEGIN))
@@ -244,9 +244,9 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length)
 
   if (offset != _offset)
   {
-    LONG* ptrfilesize = (LONG*)&filesize;
-    LONG lowoffset = ptrfilesize[0];
-    LONG highoffset = ptrfilesize[1];
+    LONG* ptroffset = (LONG*)&_offset;
+    LONG lowoffset = ptroffset[0];
+    LONG highoffset = ptroffset[1];
 
     // Seek to the required offset
     if (INVALID_SET_FILE_POINTER == SetFilePointer(hFile, lowoffset, &highoffset, FILE_BEGIN))


### PR DESCRIPTION
The aliasing waring was given for similar constructs of
((LONG*)&filesize)[0] and ((LONG*)_offset)[0]. The update introduced in
1713190de7af346c29496a080815835071d3b17f copy pasted the filesize fix to
the _offset areas, so the values used there were wrong, introducing an
800 byte offset in all par2 files and completely corrupt par2 content
when creating new parfiles on windows.

Bug-introduced: 1713190de7af346c29496a080815835071d3b17f
Fixes: #109

Signed-off-by: BlackEagle <ike.devolder@gmail.com>