### PR TITLE
Support file I/O on blocksize greater than 4GB

### DIFF
--- a/src/diskfile.h
+++ b/src/diskfile.h
@@ -21,6 +21,19 @@
 #ifndef __DISKFILE_H__
 #define __DISKFILE_H__
 
+
+// MAX_LENGTH is the maximum read/write size.  It can be OS-dependant.
+// The "& ~7" is to make it 8-byte aligned.
+// LengthType is the type required for the read/write by the OS.
+#ifdef _WIN32
+#define MAX_LENGTH (0xffffffffUL & ~7)
+#define LengthType DWORD
+#else // !_WIN32
+#define MAX_LENGTH (0xffffffffUL & ~7)
+#define LengthType size_t
+#endif
+
+
 #include <list>
 using std::list;
 #include <map>
@@ -45,7 +58,9 @@ public:
   bool Create(string filename, u64 filesize);
 
   // Write some data to the file
-  bool Write(u64 offset, const void *buffer, size_t length);
+  // maxlength should be the default value, except during testing.
+  bool Write(u64 offset, const void *buffer, size_t length,
+	     LengthType maxlength = MAX_LENGTH);
 
   // Open the file
   bool Open(void);
@@ -60,7 +75,9 @@ public:
 #endif
 
   // Read some data from the file
-  bool Read(u64 offset, void *buffer, size_t length);
+  // maxlength should be the default value, except during testing.
+  bool Read(u64 offset, void *buffer, size_t length,
+	    LengthType maxlength = MAX_LENGTH);
 
   // Close the file
   void Close(void);


### PR DESCRIPTION
Currently, when a blocksize is greater than 4GB, a call to DiskFile::Read() or DiskFile::Write() fails.  This commit changes it, so that larger reads are broken into smaller ones.  This is necessary on Windows, which limits its calls to <4GB.

The change on Unix is less necessary.  The C library can break up large reads and writes into smaller OS calls on its own.  It would be weird to have a limit of 32-bit reads on a 64-bit filesystem.  But maybe it happens in Cygwin?  