### PR TITLE
Used _stati64() for WIN32 DiskFile::FileExists()

### DIFF
--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -430,6 +430,12 @@ u64 DiskFile::GetFileSize(string filename)
   }
 }
 
+bool DiskFile::FileExists(string filename)
+{
+  struct _stati64 st;
+  return ((0 == _stati64(filename.c_str(), &st)) && (0 != (st.st_mode & S_IFREG)));
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #else // !_WIN32
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -907,6 +913,12 @@ u64 DiskFile::GetFileSize(string filename)
     return 0;
   }
 }
+
+bool DiskFile::FileExists(string filename)
+{
+  struct stat st;
+  return ((0 == stat(filename.c_str(), &st)) && (0 != (st.st_mode & S_IFREG)));
+}
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #endif
 
@@ -981,12 +993,6 @@ void DiskFile::SplitRelativeFilename(string filename, string basepath, string &n
 {
   name = filename;
   name.erase(0, basepath.length());
-}
-
-bool DiskFile::FileExists(string filename)
-{
-  struct stat st;
-  return ((0 == stat(filename.c_str(), &st)) && (0 != (st.st_mode & S_IFREG)));
 }
 
 bool DiskFile::Rename(void)


### PR DESCRIPTION
The original call to stat() failed on WIN32 for large (> 2GB) files.  I moved DiskFile::FileExists() into the WIN32/Unix sections next to GetFileSize() so that Unix builds would still get the stat() version.

Having FileExists() and GetFileSize() adjacent is also useful because GetFileSize() has the same stat/_stati64 difference between WIN32/Unix.