### PR TITLE
fix: enforce -qq silent

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -102,6 +102,7 @@ EXTRA_DIST = PORTING ROADMAP \
 			 tests/test25 \
 			 tests/test26 \
 			 tests/test27 \
+			 tests/test28 \
 			 tests/unit_tests
 
 
@@ -165,6 +166,7 @@ TESTS = tests/test1 \
 		tests/test25 \
 		tests/test26 \
 		tests/test27 \
+		tests/test28 \
 		tests/unit_tests
 
 install-exec-hook :

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -1306,7 +1306,6 @@ bool CommandLine::ComputeRecoveryBlockCount(u32 *recoveryblockcount,
     return false;
   }
 
-  cout << endl;
   return true;
 }
 

--- a/tests/test28
+++ b/tests/test28
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+execdir="$PWD"
+
+# valgrind tests memory usage.
+# wine allow for windows testing on linux
+if [ -n "${PARVALGRINDOPTS+set}" ]
+then
+    PARBINARY="valgrind $PARVALGRINDOPTS $execdir/par2"
+elif [ "`which wine`" != "" ] && [ -f "$execdir/par2.exe" ]
+then
+    PARBINARY="wine $execdir/par2.exe"
+else
+    PARBINARY="$execdir/par2"
+fi
+
+
+if [ -z "$srcdir" ] || [ "." = "$srcdir" ]; then
+  srcdir="$PWD"
+  TESTDATA="$srcdir/tests"
+else
+  srcdir="$PWD/$srcdir"
+  TESTDATA="$srcdir/tests"
+fi
+
+TESTROOT="$PWD"
+
+testname=$(basename $0)
+rm -f "$testname.log"
+rm -rf "run$testname"
+
+mkdir "run$testname" && cd "run$testname" || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
+
+cd "$TESTROOT"
+rm -rf "run$testname"
+
+exit 0;
+

--- a/tests/test28
+++ b/tests/test28
@@ -31,6 +31,22 @@ rm -rf "run$testname"
 
 mkdir "run$testname" && cd "run$testname" || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
 
+tar -xzf "$TESTDATA/flatdata.tar.gz" || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+
+banner="Ensuring silent noise level"
+dashes=`echo "$banner" | sed s/./-/g`
+
+echo $dashes
+echo $banner
+echo $dashes
+
+$PARBINARY c -a newtest -qq test-*.data >output || { echo "ERROR: Creating PAR 2.0 data failed" ; exit 1; } >&2
+test ! -s output || { echo "ERROR: create with -qq was not silent" ; exit 1; } >&2
+$PARBINARY v -qq newtest test-*.data >output || { echo "ERROR: Verifying PAR 2.0 data failed" ; exit 1; } >&2
+test ! -s output || { echo "ERROR: verify with -qq was not silent" ; exit 1; } >&2
+$PARBINARY r -qq newtest test-*.data >output || { echo "ERROR: Repairing PAR 2.0 data failed" ; exit 1; } >&2
+test ! -s output || { echo "ERROR: repair with -qq was not silent" ; exit 1; } >&2
+
 cd "$TESTROOT"
 rm -rf "run$testname"
 

--- a/tests/test28
+++ b/tests/test28
@@ -47,6 +47,10 @@ test ! -s stdout || { echo "ERROR: verify with -qq was not silent" ; exit 1; } >
 $PARBINARY r -qq newtest test-*.data >stdout || { echo "ERROR: repair failed" ; exit 1; } >&2
 test ! -s stdout || { echo "ERROR: repair with -qq was not silent" ; exit 1; } >&2
 
+$PARBINARY c -a newtest -qq test-*.data >stdout 2>stderr && { echo "ERROR: second create succeeded but shouldn't have" ; exit 1; } >&2
+test ! -s stdout || { echo "ERROR: second create with -qq was not silent" ; exit 1; } >&2
+test -s stderr || { echo "ERROR: second create with -qq did not produce output to stderr" ; exit 1; } >&2
+
 cd "$TESTROOT"
 rm -rf "run$testname"
 

--- a/tests/test28
+++ b/tests/test28
@@ -41,14 +41,14 @@ echo $banner
 echo $dashes
 
 $PARBINARY c -a newtest -qq test-*.data >stdout || { echo "ERROR: create failed" ; exit 1; } >&2
-test ! -s stdout || { echo "ERROR: create with -qq was not silent" ; exit 1; } >&2
+test ! -s stdout || { echo "ERROR: create with -qq produced output to stdout" ; exit 1; } >&2
 $PARBINARY v -qq newtest test-*.data >stdout || { echo "ERROR: verify failed" ; exit 1; } >&2
-test ! -s stdout || { echo "ERROR: verify with -qq was not silent" ; exit 1; } >&2
+test ! -s stdout || { echo "ERROR: verify with -qq produced output to stdout" ; exit 1; } >&2
 $PARBINARY r -qq newtest test-*.data >stdout || { echo "ERROR: repair failed" ; exit 1; } >&2
-test ! -s stdout || { echo "ERROR: repair with -qq was not silent" ; exit 1; } >&2
+test ! -s stdout || { echo "ERROR: repair with -qq produced output to stdout" ; exit 1; } >&2
 
 $PARBINARY c -a newtest -qq test-*.data >stdout 2>stderr && { echo "ERROR: second create succeeded but shouldn't have" ; exit 1; } >&2
-test ! -s stdout || { echo "ERROR: second create with -qq was not silent" ; exit 1; } >&2
+test ! -s stdout || { echo "ERROR: second create with -qq produced output to stdout" ; exit 1; } >&2
 test -s stderr || { echo "ERROR: second create with -qq did not produce output to stderr" ; exit 1; } >&2
 
 cd "$TESTROOT"

--- a/tests/test28
+++ b/tests/test28
@@ -40,12 +40,12 @@ echo $dashes
 echo $banner
 echo $dashes
 
-$PARBINARY c -a newtest -qq test-*.data >output || { echo "ERROR: Creating PAR 2.0 data failed" ; exit 1; } >&2
-test ! -s output || { echo "ERROR: create with -qq was not silent" ; exit 1; } >&2
-$PARBINARY v -qq newtest test-*.data >output || { echo "ERROR: Verifying PAR 2.0 data failed" ; exit 1; } >&2
-test ! -s output || { echo "ERROR: verify with -qq was not silent" ; exit 1; } >&2
-$PARBINARY r -qq newtest test-*.data >output || { echo "ERROR: Repairing PAR 2.0 data failed" ; exit 1; } >&2
-test ! -s output || { echo "ERROR: repair with -qq was not silent" ; exit 1; } >&2
+$PARBINARY c -a newtest -qq test-*.data >stdout || { echo "ERROR: Creating PAR 2.0 data failed" ; exit 1; } >&2
+test ! -s stdout || { echo "ERROR: create with -qq was not silent" ; exit 1; } >&2
+$PARBINARY v -qq newtest test-*.data >stdout || { echo "ERROR: Verifying PAR 2.0 data failed" ; exit 1; } >&2
+test ! -s stdout || { echo "ERROR: verify with -qq was not silent" ; exit 1; } >&2
+$PARBINARY r -qq newtest test-*.data >stdout || { echo "ERROR: Repairing PAR 2.0 data failed" ; exit 1; } >&2
+test ! -s stdout || { echo "ERROR: repair with -qq was not silent" ; exit 1; } >&2
 
 cd "$TESTROOT"
 rm -rf "run$testname"

--- a/tests/test28
+++ b/tests/test28
@@ -40,11 +40,11 @@ echo $dashes
 echo $banner
 echo $dashes
 
-$PARBINARY c -a newtest -qq test-*.data >stdout || { echo "ERROR: Creating PAR 2.0 data failed" ; exit 1; } >&2
+$PARBINARY c -a newtest -qq test-*.data >stdout || { echo "ERROR: create failed" ; exit 1; } >&2
 test ! -s stdout || { echo "ERROR: create with -qq was not silent" ; exit 1; } >&2
-$PARBINARY v -qq newtest test-*.data >stdout || { echo "ERROR: Verifying PAR 2.0 data failed" ; exit 1; } >&2
+$PARBINARY v -qq newtest test-*.data >stdout || { echo "ERROR: verify failed" ; exit 1; } >&2
 test ! -s stdout || { echo "ERROR: verify with -qq was not silent" ; exit 1; } >&2
-$PARBINARY r -qq newtest test-*.data >stdout || { echo "ERROR: Repairing PAR 2.0 data failed" ; exit 1; } >&2
+$PARBINARY r -qq newtest test-*.data >stdout || { echo "ERROR: repair failed" ; exit 1; } >&2
 test ! -s stdout || { echo "ERROR: repair with -qq was not silent" ; exit 1; } >&2
 
 cd "$TESTROOT"


### PR DESCRIPTION
Enforce that the `-qq` silent noise level is truly silent (i.e. gives no
output).  Fix it for `create`.  Add a test `test28` to ensure it for
`create`, `verify`, and `repair`.
