### PR TITLE
fix: allow single char filename

### DIFF
--- a/src/descriptionpacket.cpp
+++ b/src/descriptionpacket.cpp
@@ -206,7 +206,7 @@ string DescriptionPacket::TranslateFilenameFromLocalToPar2(std::ostream &sout, s
   // Par files should never contain an absolute path.  On Windows,
   // These start "C:\...", etc.  An attacker could put an absolute
   // path into a Par file and overwrite system files.
-  if (par2_encoded_filename.at(1) == ':')
+  if (par2_encoded_filename.size() > 1 && par2_encoded_filename.at(1) == ':')
   {
     if (noiselevel >= nlNormal)
     {


### PR DESCRIPTION
A `string::at` call on `pos` `1` could be called on a string that is one
character long, so it throws an `out_of_range` and core dumps.  Avoid
this by checking the string size beforehand.

Test: `echo abc >/tmp/f && par2 c /tmp/f`

Close: #145