### PR TITLE
Allow Creating Files With Over 100% Redundancy

### DIFF
--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -484,6 +484,10 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
                 cerr << "Cannot set redundancy to 0 and file count > 0" << endl;
                 return false;
               }
+	      if (redundancy > 100)
+	      {
+	        cerr << "WARNING: Creating recovery file(s) with " << redundancy << "% redundancy." << endl;
+	      }
             }
             redundancyset = true;
           }

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -474,7 +474,7 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
                 redundancy = redundancy * 10 + (*p - '0');
                 p++;
               }
-              if (redundancy > 100 || *p)
+              if (*p)
               {
                 cerr << "Invalid redundancy option: " << argv[0] << endl;
                 return false;


### PR DESCRIPTION
While this may seem crazy, it makes sense when dealing with small files of extremely high value.

This can already be set by using `-r<c><file_size>*2.