### PR TITLE
CRC32/MD5 optimisations

### DIFF
--- a/src/crc.cpp
+++ b/src/crc.cpp
@@ -35,12 +35,46 @@ static char THIS_FILE[]=__FILE__;
 // https://en.wikipedia.org/wiki/Cyclic_redundancy_check
 crc32table ccitttable(0xEDB88320L);
 
+
+// GF32 multiplication
+#define NEGATE32(n) (u32)(-((i32)(n)))
+static u32 GF32Multiply(u32 a, u32 b, u32 polynomial)
+{
+  u32 product = 0;
+  for (u32 i=0; i<31; i++)
+  {
+    product ^= NEGATE32(b >> 31) & a;
+    a = ((a >> 1) ^ (polynomial & NEGATE32(a & 1)));
+    b <<= 1;
+  }
+  product ^= NEGATE32(b >> 31) & a;
+  return product;
+}
+
+// Compute 2^(8n) in CRC's GF
+static u32 CRCExp8(u64 n)
+{
+  u32 result = 0x80000000;
+  u32 power = 0;
+  n %= 0xffffffff;
+  while (n)
+  {
+    if (n & 1)
+      result = GF32Multiply(result, ccitttable.power[power], ccitttable.polynom);
+    n >>= 1;
+    power = (power + 1) & 31;
+  }
+  return result;
+}
+
+
 // Construct the CRC32 lookup table from the specified polynomial
 //
 // This seems to follow:
 // http://www.efg2.com/Lab/Library/UseNet/1999/0117.txt
-void GenerateCRC32Table(u32 polynomial, u32 (&table)[256])
+crc32table::crc32table(u32 polynomial)
 {
+  polynom = polynomial;
   for (u32 i = 0; i <= 255 ; i++)
   {
     u32 crc = i;
@@ -52,36 +86,37 @@ void GenerateCRC32Table(u32 polynomial, u32 (&table)[256])
 
     table[i] = crc;
   }
+  
+  // Also construct the table used for computing power
+  // Note that the table is rotated by 3 entries, since we operate on bytes, i.e. 1<<3 bits
+  u32 k = 0x80000000 >> 1;
+  for (u32 i = 0; i < 32; i++)
+  {
+    power[(i - 3) & 31] = k;
+    k = GF32Multiply(k, k, polynomial);
+  }
 }
 
 // Construct a CRC32 lookup table for windowing
 void GenerateWindowTable(u64 window, u32 (&target)[256])
 {
-  #pragma omp parallel for
+  // Window coefficient
+  u32 coeff = CRCExp8(window);
+  // Extend initial CRC to window length
+  u32 mask = GF32Multiply(~0, coeff, ccitttable.polynom);
+  // Xor initial CRC with that extended by one byte
+  mask = GF32Multiply(mask, 0x80800000, ccitttable.polynom);
+  // Since we have a table, may as well invert all bits to save doing it later
+  mask ^= ~0;
+  
+  // Generate table
   for (i16 i=0; i<=255; i++)
   {
-    u32 crc = ccitttable.table[i];
-
-    for (u64 j=0; j<window; j++)
-    {
-      crc = ((crc >> 8) & 0x00ffffffL) ^ ccitttable.table[(u8)crc];
-    }
-
-    target[i] = crc;
+    target[i] = GF32Multiply(ccitttable.table[i], coeff, ccitttable.polynom) ^ mask;
   }
 }
 
-// Construct the mask value to apply to the CRC when windowing
-u32 ComputeWindowMask(u64 window)
+u32 CRCUpdateBlock(u32 crc, u64 length)
 {
-  u32 result = ~0;
-  while (window > 0)
-  {
-    result = CRCUpdateChar(result, (char)0);
-
-    window--;
-  }
-  result ^= ~0;
-
-  return result;
+  return GF32Multiply(crc, CRCExp8(length), ccitttable.polynom);
 }

--- a/src/crc_test.cpp
+++ b/src/crc_test.cpp
@@ -170,7 +170,6 @@ int test5() {
 
   u32 windowtable[256];
   GenerateWindowTable(window, windowtable);
-  u32 windowmask = ComputeWindowMask(window);
 
   int result = 0;
 
@@ -186,7 +185,7 @@ int test5() {
     }
 
     // slide window
-    crc = windowmask ^ CRCSlideChar(windowmask ^ crc, buffer[offset + window], buffer[offset], windowtable);
+    crc = CRCSlideChar(crc, buffer[offset + window], buffer[offset], windowtable);
   }
 
   return result;
@@ -197,7 +196,7 @@ int test5() {
 // stolen from:
 // http://www.efg2.com/Lab/Mathematics/CRC.htm
 int test6() {
-  u32 checksum1 = ~0 ^ CRCUpdateBlock(~0, sizeof(ccitttable), &ccitttable);
+  u32 checksum1 = ~0 ^ CRCUpdateBlock(~0, sizeof(ccitttable.table), &ccitttable.table);
   u32 expected = 0x6FCF9E13;
   if (checksum1 != expected) {
       cerr << "error when computing checksum of checksum table " << endl;

--- a/src/filechecksummer.cpp
+++ b/src/filechecksummer.cpp
@@ -32,12 +32,10 @@ static char THIS_FILE[]=__FILE__;
 
 FileCheckSummer::FileCheckSummer(DiskFile   *_diskfile,
                                  u64         _blocksize,
-                                 const u32 (&_windowtable)[256],
-                                 u32         _windowmask)
+                                 const u32 (&_windowtable)[256])
 : diskfile(_diskfile)
 , blocksize(_blocksize)
 , windowtable(_windowtable)
-, windowmask(_windowmask)
 , filesize(_diskfile->FileSize())
 , currentoffset(0)
 , buffer(0)

--- a/src/filechecksummer.h
+++ b/src/filechecksummer.h
@@ -39,8 +39,7 @@ class FileCheckSummer
 public:
   FileCheckSummer(DiskFile   *diskfile,
                   u64         blocksize,
-                  const u32 (&windowtable)[256],
-                  u32         windowmask);
+                  const u32 (&windowtable)[256]);
   ~FileCheckSummer(void);
 
   // Start reading the file at the beginning
@@ -79,7 +78,6 @@ protected:
   DiskFile   *diskfile;
   u64         blocksize;
   const u32 (&windowtable)[256];
-  u32         windowmask;
 
   u64         filesize;
 
@@ -162,7 +160,7 @@ inline bool FileCheckSummer::Step(void)
   char outch = *outpointer++;
 
   // Update the checksum
-  checksum = windowmask ^ CRCSlideChar(windowmask ^ checksum, inch, outch, windowtable);
+  checksum = CRCSlideChar(checksum, inch, outch, windowtable);
 
   // Can the window slide further
   if (outpointer < &buffer[blocksize])

--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -78,8 +78,8 @@ inline void MD5Context::UpdateState(const unsigned char* current)
 #endif
 
   // Primitive operations
-#define F1(x,y,z)    ( ((x) & (y)) | ((~(x)) & (z)) )
-#define F2(x,y,z)    ( ((x) & (z)) | ((~(z)) & (y)) )
+#define F1(x,y,z)    ( (((y) ^ (z)) & (x)) ^ (z) )
+#define F2(x,y,z)    ((x) & (z)) + ((~(z)) & (y))
 #define F3(x,y,z)    ( (x) ^ (y) ^ (z) )
 #define F4(x,y,z)    ( (y) ^ ( (x) | ~(z) ) )
 

--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -58,23 +58,25 @@ string MD5Hash::print(void) const
   return buffer;
 }
 
-MD5State::MD5State(void)
-{
-  Reset();
-}
-
-// Initialise the 16 byte state
-void MD5State::Reset(void)
-{
-  state[0] = 0x67452301;
-  state[1] = 0xefcdab89;
-  state[2] = 0x98badcfe;
-  state[3] = 0x10325476;
-}
-
 // Update the state using 64 bytes of new data
-void MD5State::UpdateState(const u32 (&block)[16])
+inline void MD5Context::UpdateState(const unsigned char* current)
 {
+#if __BYTE_ORDER != __LITTLE_ENDIAN
+  u32 wordblock[16];
+  for (int i=0; i<16; i++)
+  {
+    // Convert source data from little endian format to internal format if different
+    wordblock[i] = ( ((u32)current[i*4+3]) << 24 ) |
+                   ( ((u32)current[i*4+2]) << 16 ) |
+                   ( ((u32)current[i*4+1]) <<  8 ) |
+                   ( ((u32)current[i*4+0]) <<  0 );
+  }
+#  define ROUND(f,w,x,y,z,k,s,ti)   w = x + ROL(w + f(x,y,z) + wordblock[k] + ti, s)
+#else
+  u32 input;
+#  define ROUND(f,w,x,y,z,k,s,ti)   memcpy(&input, &current[(k)*4], 4); w = x + ROL(w + f(x,y,z) + input + ti, s)
+#endif
+
   // Primitive operations
 #define F1(x,y,z)    ( ((x) & (y)) | ((~(x)) & (z)) )
 #define F2(x,y,z)    ( ((x) & (z)) | ((~(z)) & (y)) )
@@ -85,7 +87,6 @@ void MD5State::UpdateState(const u32 (&block)[16])
 //#define ROL(x,y)   ( ((x) << (y)) | (((unsigned int)x) >> (32-y)) )
 #define ROL(x,y)     ( ((x) << (y)) | (((x) >> (32-y)) & ((1<<y)-1)))
 
-#define ROUND(f,w,x,y,z,k,s,ti)   w = x + ROL(w + f(x,y,z) + block[k] + ti, s)
 
   u32 a = state[0];
   u32 b = state[1];
@@ -179,16 +180,20 @@ void MD5State::UpdateState(const u32 (&block)[16])
 }
 
 MD5Context::MD5Context(void)
-: MD5State()
-, used(0)
+: used(0)
 , bytes(0)
 {
   memset(block, 0, buffersize);
+  Reset();
 }
 
+// Initialise the 16 byte state
 void MD5Context::Reset(void)
 {
-  MD5State::Reset();
+  state[0] = 0x67452301;
+  state[1] = 0xefcdab89;
+  state[2] = 0x98badcfe;
+  state[3] = 0x10325476;
   used = 0;
   bytes = 0;
 }
@@ -231,8 +236,8 @@ void MD5Context::Update(const void *buffer, size_t length)
   // Update the total amount of data processed.
   bytes += length;
 
-  // Process any whole blocks
-  while (used + length >= buffersize)
+  // Process first whole block if we have something in the buffer
+  if (used && used + length >= buffersize)
   {
     size_t have = buffersize - used;
 
@@ -241,19 +246,17 @@ void MD5Context::Update(const void *buffer, size_t length)
     current += have;
     length -= have;
 
-    u32 wordblock[16];
-    for (int i=0; i<16; i++)
-    {
-      // Convert source data from little endian format to internal format if different
-      wordblock[i] = ( ((u32)block[i*4+3]) << 24 ) |
-                     ( ((u32)block[i*4+2]) << 16 ) |
-                     ( ((u32)block[i*4+1]) <<  8 ) |
-                     ( ((u32)block[i*4+0]) <<  0 );
-    }
-
-    MD5State::UpdateState(wordblock);
+    UpdateState(block);
 
     used = 0;
+  }
+
+  // Process all subsequent whole blocks
+  while (length >= buffersize)
+  {
+    UpdateState(current);
+    current += buffersize;
+    length -= buffersize;
   }
 
   // Store any remainder
@@ -301,10 +304,10 @@ void MD5Context::Final(MD5Hash &output)
   for (int i = 0; i < 4; i++)
   {
     // Read out the state and convert it from internal format to little endian format
-    output.hash[4*i+3] = (u8)((MD5State::state[i] >> 24) & 0xFF);
-    output.hash[4*i+2] = (u8)((MD5State::state[i] >> 16) & 0xFF);
-    output.hash[4*i+1] = (u8)((MD5State::state[i] >>  8) & 0xFF);
-    output.hash[4*i+0] = (u8)((MD5State::state[i] >>  0) & 0xFF);
+    output.hash[4*i+3] = (u8)((state[i] >> 24) & 0xFF);
+    output.hash[4*i+2] = (u8)((state[i] >> 16) & 0xFF);
+    output.hash[4*i+1] = (u8)((state[i] >>  8) & 0xFF);
+    output.hash[4*i+0] = (u8)((state[i] >>  0) & 0xFF);
   }
 }
 
@@ -316,10 +319,10 @@ MD5Hash MD5Context::Hash(void) const
   for (unsigned int i = 0; i < 4; i++)
   {
     // Read out the state and convert it from internal format to little endian format
-    output.hash[4*i+3] = (unsigned char)((MD5State::state[i] >> 24) & 0xFF);
-    output.hash[4*i+2] = (unsigned char)((MD5State::state[i] >> 16) & 0xFF);
-    output.hash[4*i+1] = (unsigned char)((MD5State::state[i] >>  8) & 0xFF);
-    output.hash[4*i+0] = (unsigned char)((MD5State::state[i] >>  0) & 0xFF);
+    output.hash[4*i+3] = (unsigned char)((state[i] >> 24) & 0xFF);
+    output.hash[4*i+2] = (unsigned char)((state[i] >> 16) & 0xFF);
+    output.hash[4*i+1] = (unsigned char)((state[i] >>  8) & 0xFF);
+    output.hash[4*i+0] = (unsigned char)((state[i] >>  0) & 0xFF);
   }
 
   return output;

--- a/src/md5.h
+++ b/src/md5.h
@@ -64,24 +64,9 @@ struct MD5Hash
   u8 hash[16]; // 16 byte MD5 Hash value
 } PACKED;
 
-// Intermediate computation state
-
-class MD5State
-{
-public:
-  MD5State(void);
-  void Reset(void);
-
-public:
-  void UpdateState(const u32 (&block)[16]);
-
-protected:
-  u32 state[4]; // 16 byte MD5 computation state
-};
-
 // MD5 computation context with 64 byte buffer
 
-class MD5Context : public MD5State
+class MD5Context
 {
 public:
   MD5Context(void);
@@ -108,8 +93,12 @@ protected:
   enum {buffersize = 64};
   unsigned char block[buffersize];
   size_t used;
+  u32 state[4]; // 16 byte MD5 computation state
 
   u64 bytes;
+
+private:
+  void UpdateState(const unsigned char* current);
 };
 
 // Compare hash values

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -51,7 +51,6 @@ Par2Repairer::Par2Repairer(std::ostream &sout, std::ostream &serr, const NoiseLe
 , par2list()
 , sourceblocks()
 , targetblocks()
-, windowmask(0)
 , blockverifiable(false)
 , verificationhashtable()
 , unverifiablesourcefiles()
@@ -1147,7 +1146,6 @@ bool Par2Repairer::ComputeWindowTable(void)
   if (blockverifiable)
   {
     GenerateWindowTable(blocksize, windowtable);
-    windowmask = ComputeWindowMask(blocksize);
   }
 
   return true;
@@ -1602,7 +1600,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
   }
 
   // Create the checksummer for the file and start reading from it
-  FileCheckSummer filechecksummer(diskfile, blocksize, windowtable, windowmask);
+  FileCheckSummer filechecksummer(diskfile, blocksize, windowtable);
   if (!filechecksummer.Start())
     return false;
 

--- a/src/par2repairer.h
+++ b/src/par2repairer.h
@@ -186,7 +186,6 @@ protected:
   vector<DataBlock>         targetblocks;            // The DataBlocks that will be written to disk
 
   u32                       windowtable[256];        // Table for sliding CRCs
-  u32                       windowmask;              // Mask for sliding CRCs
 
   bool                            blockverifiable;         // Whether and files can be verified at the block level
   VerificationHashTable           verificationhashtable;   // Hash table for block verification


### PR DESCRIPTION
I noticed that a few simple things could be done to improve hashing performance:

* CRC32 zero extension can be computed using GF arithmetic instead of passing 0s through. Doing so greatly speeds up the window table generation
* the CRC window mask can be incorporated into the window table itself, saving the mask operation. Speed difference is likely negligible, but it simplifies code
* avoid unnecessarily copying blocks in MD5 on little endian CPUs
* slightly faster MD5 round expressions

(I don't really see par2cmdline being highly performance focused, but these are relatively simple tweaks which I thought would make sense to have)