### PR TITLE
Avoid copying back memory in FileChecksummer when data is valid

### DIFF
--- a/src/filechecksummer.cpp
+++ b/src/filechecksummer.cpp
@@ -135,14 +135,20 @@ bool FileCheckSummer::Jump(u64 distance)
 
 // Fill the buffer from disk
 
-bool FileCheckSummer::Fill(void)
+bool FileCheckSummer::Fill(bool longfill)
 {
   // Have we already reached the end of the file
   if (readoffset >= filesize)
     return true;
 
+  // Don't bother filling if we have enough data in the buffer
+  if (tailpointer >= &buffer[blocksize] && !longfill)
+    return true;
+
+  // Try reading at least one block of data
+  const char *target = tailpointer == buffer ? &buffer[blocksize] : &buffer[2*blocksize];
   // How much data can we read into the buffer
-  size_t want = (size_t)min(filesize-readoffset, (u64)(&buffer[2*blocksize]-tailpointer));
+  size_t want = (size_t)min(filesize-readoffset, (u64)(target-tailpointer));
 
   if (want > 0)
   {
@@ -156,7 +162,7 @@ bool FileCheckSummer::Fill(void)
   }
 
   // Did we fill the buffer
-  want = &buffer[2*blocksize] - tailpointer;
+  want = target - tailpointer;
   if (want > 0)
   {
     // Blank the rest of the buffer

--- a/src/filechecksummer.h
+++ b/src/filechecksummer.h
@@ -104,7 +104,8 @@ protected:
   void UpdateHashes(u64 offset, const void *buffer, size_t length);
 
   //// Fill the buffers with more data from disk
-  bool Fill(void);
+  // Set longfill = true to force fill the whole buffer
+  bool Fill(bool longfill = false);
 
 private:
   // private copy constructor to prevent any misuse.
@@ -157,6 +158,11 @@ inline bool FileCheckSummer::Step(void)
     return true;
   }
 
+  // Ensure we have enough data in the buffer
+  if (tailpointer <= inpointer)
+    if(!Fill(true))
+      return false;
+
   // Get the incoming and outgoing characters
   char inch = *inpointer++;
   char outch = *outpointer++;
@@ -171,13 +177,12 @@ inline bool FileCheckSummer::Step(void)
   assert(outpointer == &buffer[blocksize]);
 
   // Copy the data back to the beginning of the buffer
-  memmove(buffer, outpointer, (size_t)blocksize);
+  memcpy(buffer, outpointer, (size_t)blocksize);
   inpointer = outpointer;
   outpointer = buffer;
   tailpointer -= blocksize;
 
-  // Fill the rest of the buffer
-  return Fill();
+  return true;
 }
 
 


### PR DESCRIPTION
The current FileChecksummer almost always [performs a memory copy](https://github.com/Parchive/par2cmdline/blob/0b266b5d41669fc1977f327c5d7e422b1ef06ac8/src/filechecksummer.cpp#L112-L116) once a read has occurred. This is because it fills the entire buffer, and every `Jump` call can, at most, consume half that buffer, leading to `keep` being greater than 0 in all cases except reaching the end-of-file.

This seemingly unnecessary copying around of memory seems rather wasteful.  
A solution may be to turn the buffer into some sort of circular buffer, however implementing such is rather complex/fiddly.

With the goal of simplicity, I've implemented a much easier approach that yields most of the benefit - instead of filling the buffer completely, only fill it half way, most of the time. Since the buffer can only be consumed til the half-way point, this is safe.  
Assuming all data is valid, this makes `keep == 0` stay true throughout the process, avoiding the memory copy.

This leaves cases where data isn't valid, causing `Step` or `Jump` (with smaller distances) to be called. In such cases, it just reverts to existing behavior of filling the buffer completely, and moving the data to the beginning of the buffer (in `Jump`s case). If the data becomes valid again, it'll revert to filling the buffer halfway.

The assumption is that most data will be valid in typical usage scenarios, leading to a speedup most of the time.

Also the `memmove` in `Step` can be replaced with `memcpy` as the regions are guaranteed to be non-overlapping.