### PR TITLE
enable Recurse flag on Windows OS

### DIFF
--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -397,8 +397,7 @@ std::unique_ptr< list<string> > DiskFile::FindFiles(string path, string wildcard
       {
         matches->push_back(path + fd.cFileName);
       }
-      else if ((0 != (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) &&
-               (recursive == true))
+      else if (recursive == true)
       {
         if (fd.cFileName[0] == '.') {
           continue;

--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -397,7 +397,8 @@ std::unique_ptr< list<string> > DiskFile::FindFiles(string path, string wildcard
       {
         matches->push_back(path + fd.cFileName);
       }
-      else if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+      else if ((0 != (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) &&
+               (recursive == true))
       {
         if (fd.cFileName[0] == '.') {
           continue;
@@ -407,6 +408,10 @@ std::unique_ptr< list<string> > DiskFile::FindFiles(string path, string wildcard
 	std::unique_ptr< list<string> > dirmatches(
 						 DiskFile::FindFiles(path + fd.cFileName, nwwildcard, true)
 						 );
+
+        // sort both lists before merge
+        matches->sort();
+        dirmatches->sort();
 
         matches->merge(*dirmatches);
       }


### PR DESCRIPTION
I updated diskfile.cpp to fix the bug, which I posted at [issues #169](https://github.com/Parchive/par2cmdline/issues/169) ago. 
The bug was reported at [issues #173](https://github.com/Parchive/par2cmdline/issues/173), too.