### PR TITLE
POC for a rename only mode

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -31,9 +31,6 @@
 /* Define to 1 if you have the `memcpy' function. */
 #undef HAVE_MEMCPY
 
-/* Define to 1 if you have the <memory.h> header file. */
-#undef HAVE_MEMORY_H
-
 /* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
 #undef HAVE_NDIR_H
 
@@ -105,7 +102,9 @@
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
-/* Define to 1 if you have the ANSI C header files. */
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
 #undef STDC_HEADERS
 
 /* Version number of package */
@@ -121,11 +120,6 @@
 # ifndef WORDS_BIGENDIAN
 #  undef WORDS_BIGENDIAN
 # endif
-#endif
-
-/* Enable large inode numbers on Mac OS X 10.5.  */
-#ifndef _DARWIN_USE_64_BIT_INODE
-# define _DARWIN_USE_64_BIT_INODE 1
 #endif
 
 /* Number of bits in a file offset, on hosts where this is settable. */

--- a/configure.ac
+++ b/configure.ac
@@ -22,8 +22,8 @@ dnl  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 dnl                                               -*- Autoconf -*-
 dnl Process this file with autoconf to produce a configure script.
 
-AC_PREREQ(2.62)
-AC_INIT([par2cmdline], [0.8.1], [ike.devolder@gmail.com])
+AC_PREREQ([2.71])
+AC_INIT([par2cmdline],[0.8.1],[ike.devolder@gmail.com])
 AC_CONFIG_SRCDIR([src/par2cmdline.cpp])
 
 AC_CANONICAL_HOST
@@ -48,7 +48,15 @@ AC_LANG(C++)
 dnl Checks for header files.
 AC_HEADER_DIRENT
 AC_HEADER_STDBOOL
-AC_HEADER_STDC
+m4_warn([obsolete],
+[The preprocessor macro `STDC_HEADERS' is obsolete.
+  Except in unusual embedded environments, you can safely include all
+  ISO C90 headers unconditionally.])dnl
+# Autoupdate added the next two lines to ensure that your configure
+# script's behavior did not change.  They are probably safe to remove.
+AC_CHECK_INCLUDES_DEFAULT
+AC_PROG_EGREP
+
 AC_CHECK_HEADERS([stdio.h] [endian.h])
 AC_CHECK_HEADERS([getopt.h] [limits.h])
 

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -52,6 +52,7 @@ CommandLine::CommandLine(void)
 , extrafiles()
 , operation(opNone)
 , purgefiles(false)
+, renameonly(false)
 , skipdata(false)
 , skipleaway(0)
 , blockcount(0)
@@ -723,6 +724,16 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
               return false;
             }
             purgefiles = true;
+          }
+          break;
+        case 'M':
+          {
+            if (operation != opRepair && operation != opVerify)
+            {
+              cerr << "Cannot specify renameonly unless repairing or verifying." << endl;
+              return false;
+            }
+            renameonly = true;
           }
           break;
 

--- a/src/commandline.h
+++ b/src/commandline.h
@@ -99,6 +99,7 @@ public:
   string                              GetBasePath(void) const    {return basepath;}
   const vector<string>& GetExtraFiles(void) const  {return extrafiles;}
   bool                                GetPurgeFiles(void) const  {return purgefiles;}
+  bool                                GetRenameOnly(void) const  {return renameonly;}
   bool                                GetRecursive(void) const   {return recursive;}
   bool                                GetSkipData(void) const    {return skipdata;}
   u64                                 GetSkipLeaway(void) const  {return skipleaway;}
@@ -177,6 +178,7 @@ protected:
   // options for verify/repair operation
   bool purgefiles;             // purge backup and par files on success
                                // recovery
+  bool renameonly;             // only attempt to repair via rename			   
   bool skipdata;               // Whether we should assume that all good
                                // data blocks are within +/- bytes of
                                // where we expect to find them and should

--- a/src/libpar2.cpp
+++ b/src/libpar2.cpp
@@ -70,6 +70,7 @@ Result par2repair(std::ostream &sout,
 		  const vector<string> &extrafiles,
 		  const bool dorepair,   // derived from operation
 		  const bool purgefiles,
+		  const bool renameonly,
 		  const bool skipdata,
 		  const u64 skipleaway
 		  )
@@ -86,6 +87,7 @@ Result par2repair(std::ostream &sout,
 				   extrafiles,
 				   dorepair,
 				   purgefiles,
+				   renameonly,
 				   skipdata,
 				   skipleaway);
 

--- a/src/libpar2.h
+++ b/src/libpar2.h
@@ -168,6 +168,7 @@ Result par2repair(std::ostream &sout,
 		  const std::vector<std::string> &extrafiles,
 		  const bool dorepair,   // derived from operation
 		  const bool purgefiles,
+		  const bool renameonly,
 		  const bool skipdata,
 		  const u64 skipleaway
 		  );

--- a/src/par2cmdline.cpp
+++ b/src/par2cmdline.cpp
@@ -114,6 +114,7 @@ int main(int argc, char *argv[])
 				  commandline->GetExtraFiles(),
 				  commandline->GetOperation() == CommandLine::opRepair,
 				  commandline->GetPurgeFiles(),
+				  commandline->GetRenameOnly(),
 				  commandline->GetSkipData(),
 				  commandline->GetSkipLeaway());
               break;

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -133,6 +133,7 @@ Result Par2Repairer::Process(
 			     const vector<string> &_extrafiles,
 			     const bool dorepair,   // derived from operation
 			     const bool purgefiles,
+			     const bool renameonly,
 			     const bool _skipdata,
 			     const u64 _skipleaway
 			     )
@@ -209,7 +210,7 @@ Result Par2Repairer::Process(
   if (completefilecount < mainpacket->RecoverableFileCount())
   {
     // Scan any extra files specified on the command line
-    if (!VerifyExtraFiles(extrafiles, basepath))
+    if (!VerifyExtraFiles(extrafiles, basepath, renameonly))
       return eLogicError;
   }
 
@@ -1308,7 +1309,7 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
 }
 
 // Scan any extra files specified on the command line
-bool Par2Repairer::VerifyExtraFiles(const vector<string> &extrafiles, const string &basepath)
+bool Par2Repairer::VerifyExtraFiles(const vector<string> &extrafiles, const string &basepath, const bool renameonly)
 {
   if (noiselevel > nlQuiet)
     sout << endl << "Scanning extra files:" << endl << endl;
@@ -1358,7 +1359,7 @@ bool Par2Repairer::VerifyExtraFiles(const vector<string> &extrafiles, const stri
           assert(success);
 
           // Do the actual verification
-          VerifyDataFile(diskfile, 0, basepath);
+          VerifyDataFile(diskfile, 0, basepath, renameonly);
           // Ignore errors
 
           // We have finished with the file for now
@@ -1378,7 +1379,7 @@ bool Par2Repairer::VerifyExtraFiles(const vector<string> &extrafiles, const stri
 }
 
 // Attempt to match the data in the DiskFile with the source file
-bool Par2Repairer::VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const string &basepath)
+bool Par2Repairer::VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const string &basepath, const bool renameonly)
 {
   MatchType matchtype; // What type of match was made
   MD5Hash hashfull;    // The MD5 Hash of the whole file
@@ -1393,6 +1394,7 @@ bool Par2Repairer::VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *so
 
     if (!ScanDataFile(diskfile,   // [in]      The file to scan
                       basepath,
+		      renameonly,
                       sourcefile, // [in/out]  Modified in the match is for another source file
                       matchtype,  // [out]
                       hashfull,   // [out]
@@ -1404,6 +1406,8 @@ bool Par2Repairer::VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *so
     {
       case eNoMatch:
         // No data was found at all.
+	
+	
 
         // Continue to next test.
         break;
@@ -1555,6 +1559,7 @@ bool Par2Repairer::VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *so
 // found is for a different source file then "sourcefile" is changed accordingly.
 bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
                                 string                  basepath,     // [in]
+				const bool              renameonly,   // [in]
                                 Par2RepairerSourceFile* &sourcefile,  // [in/out]
                                 MatchType               &matchtype,   // [out]
                                 MD5Hash                 &hashfull,    // [out]
@@ -1742,6 +1747,9 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
         if (!currententry->FirstBlock() || filechecksummer.Offset() != 0)
         {
           matchtype = ePartialMatch;
+	  if (renameonly) {
+		  return false;
+	  }
         }
       }
       else
@@ -1752,6 +1760,9 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
         if (currententry != nextentry)
         {
           matchtype = ePartialMatch;
+	  if (renameonly) {
+		  return false;
+	  }
         }
 
         // Is the match from a different source file
@@ -1787,6 +1798,9 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
     {
       // This cannot be a perfect match
       matchtype = ePartialMatch;
+      if (renameonly) {
+	      return false;
+      }
 
       // Was this a duplicate match
       if (duplicate && false) // ignore duplicates

--- a/src/par2repairer.h
+++ b/src/par2repairer.h
@@ -38,6 +38,7 @@ public:
 		 const vector<string> &extrafiles,
 		 const bool dorepair,   // derived from operation
 		 const bool purgefiles,
+		 const bool renameonly,
 		 const bool skipdata,
 		 const u64 skipleaway
 		 );
@@ -87,10 +88,10 @@ protected:
   bool VerifySourceFiles(const std::string& basepath, std::vector<string>& extrafiles);
 
   // Scan any extra files specified on the command line
-  bool VerifyExtraFiles(const vector<string> &extrafiles, const string &basepath);
+  bool VerifyExtraFiles(const vector<string> &extrafiles, const string &basepath, const bool renameonly);
 
   // Attempt to match the data in the DiskFile with the source file
-  bool VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const string &basepath);
+  bool VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const string &basepath, const bool renameonly = false);
 
   // Perform a sliding window scan of the DiskFile looking for blocks of data that
   // might belong to any of the source files (for which a verification packet was
@@ -99,6 +100,7 @@ protected:
   // found is for a different source file then "sourcefile" is changed accordingly.
   bool ScanDataFile(DiskFile                *diskfile,   // [in]     The file being scanned
                     string                  basepath,    // [in]
+		    const bool              renameonly,  // [in]					 //
                     Par2RepairerSourceFile* &sourcefile, // [in/out] The source file matched
                     MatchType               &matchtype,  // [out]    The type of match
                     MD5Hash                 &hashfull,   // [out]    The full hash of the file


### PR DESCRIPTION
I through together a quick POC for issue I filed at https://github.com/Parchive/par2cmdline/issues/184

makes it so much faster to fix renaming of randomly renamed named files with par2, as it can now stop scanning as soon as it knows a file isn't a simple rename.