### PR TITLE
Support Unicode and long-paths on Windows

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,8 @@ libpar2_a_SOURCES = src/crc.cpp src/crc.h \
 	src/reedsolomon.cpp src/reedsolomon.h \
 	src/verificationhashtable.cpp src/verificationhashtable.h \
 	src/verificationpacket.cpp src/verificationpacket.h \
-	src/libpar2.cpp src/libpar2.h src/libpar2internal.h
+	src/libpar2.cpp src/libpar2.h src/libpar2internal.h \
+	src/utf8.cpp src/utf8.h
 
 
 bin_PROGRAMS = par2
@@ -117,6 +118,7 @@ tests_crc_test_SOURCES = src/crc_test.cpp src/crc.cpp src/crc.h
 tests_md5_test_SOURCES = src/md5_test.cpp src/md5.cpp src/md5.h
 
 tests_diskfile_test_SOURCES = src/diskfile_test.cpp src/diskfile.cpp src/diskfile.h
+tests_diskfile_test_LDADD = libpar2.a
 
 tests_libpar2_test_SOURCES = src/libpar2_test.cpp src/libpar2.h
 tests_libpar2_test_LDADD = libpar2.a

--- a/par2cmdline.vcxproj
+++ b/par2cmdline.vcxproj
@@ -31,17 +31,17 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v141_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v141_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v141_xp</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -200,6 +200,7 @@
     <ClCompile Include="src\par2repairersourcefile.cpp" />
     <ClCompile Include="src\recoverypacket.cpp" />
     <ClCompile Include="src\reedsolomon.cpp" />
+    <ClCompile Include="src\utf8.cpp" />
     <ClCompile Include="src\verificationhashtable.cpp" />
     <ClCompile Include="src\verificationpacket.cpp" />
   </ItemGroup>
@@ -228,6 +229,7 @@
     <ClInclude Include="src\par2repairersourcefile.h" />
     <ClInclude Include="src\recoverypacket.h" />
     <ClInclude Include="src\reedsolomon.h" />
+    <ClInclude Include="src\utf8.h" />
     <ClInclude Include="src\verificationhashtable.h" />
     <ClInclude Include="src\verificationpacket.h" />
   </ItemGroup>

--- a/par2cmdline.vcxproj.filters
+++ b/par2cmdline.vcxproj.filters
@@ -90,6 +90,9 @@
     <ClCompile Include="src\libpar2.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\utf8.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\commandline.h">
@@ -168,6 +171,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\libpar2internal.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\utf8.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -1320,10 +1320,17 @@ bool CommandLine::ComputeRecoveryBlockCount(u32 *recoveryblockcount,
 bool CommandLine::SetParFilename(string filename)
 {
   bool result = false;
+  string::size_type position = 0;
   string::size_type where;
 
-  if ((where = filename.find_first_of('*')) != string::npos ||
-      (where = filename.find_first_of('?')) != string::npos)
+#ifdef _WIN32
+  if (filename.rfind(R"(\\?\)", 0) == 0) {
+    position = strlen(R"(\\?\)");
+  }
+#endif
+
+  if ((where = filename.find_first_of('*', position)) != string::npos ||
+    (where = filename.find_first_of('?', position)) != string::npos)
   {
     cerr << "par2 file must not have a wildcard in it." << endl;
     return result;

--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -321,6 +321,11 @@ string DiskFile::GetCanonicalPathname(string filename)
 	typedef string TSTRING;
 #endif
 
+  if (filename.rfind(R"(\\?\)", 0) == 0)
+  {
+    return filename;
+  }
+
   TCHAR fullname[MAX_PATH];
   TCHAR *filepart;
 

--- a/src/libpar2internal.h
+++ b/src/libpar2internal.h
@@ -36,12 +36,21 @@
 #include <io.h>
 #include <fcntl.h>
 #include <assert.h>
+#include <tchar.h>
 
 #define snprintf _snprintf_s
 #define sprintf  sprintf_s
 #define stricmp  _stricmp
 #define unlink   _unlink
-#define stat _stat
+
+#ifdef UNICODE
+#define stat _wstati64
+#define struct_stat _stati64
+#define rename _wrename
+#else
+#define stat _stati64
+#define struct_stat _stati64
+#endif
 
 #define __LITTLE_ENDIAN 1234
 #define __BIG_ENDIAN    4321
@@ -194,6 +203,7 @@ char *strchr(), *strrchr();
 #define LONGMULTIPLY
 
 // STL includes
+#include <string>
 #include <list>
 #include <map>
 #include <algorithm>
@@ -244,6 +254,8 @@ using namespace std;
 #include "par1fileformat.h"
 #include "par1repairersourcefile.h"
 #include "par1repairer.h"
+
+#include "utf8.h"
 
 // Heap checking
 #ifdef _MSC_VER

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -352,7 +352,7 @@ bool Par2Repairer::LoadPacketsFromFile(string filename)
     string path;
     string name;
     DiskFile::SplitFilename(filename, path, name);
-    sout << "Loading \"" << name << "\"." << endl;
+    sout << "Loading \"" << utf8::console(name) << "\"." << endl;
   }
 
   // How many useable packets have we found
@@ -1295,7 +1295,7 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
         if (noiselevel > nlSilent)
         {
           #pragma omp critical
-          sout << "Target: \"" << name << "\" - missing." << endl;
+          sout << "Target: \"" << utf8::console(name) << "\" - missing." << endl;
         }
       }
     }
@@ -1578,12 +1578,12 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
       if (originalsourcefile != 0)
       {
         #pragma omp critical
-        sout << "Target: \"" << name << "\" - empty." << endl;
+        sout << "Target: \"" << utf8::console(name) << "\" - empty." << endl;
       }
       else
       {
         #pragma omp critical
-        sout << "File: \"" << name << "\" - empty." << endl;
+        sout << "File: \"" << utf8::console(name) << "\" - empty." << endl;
       }
     }
     return true;
@@ -1893,7 +1893,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
           {
             #pragma omp critical
             sout << "Target: \""
-              << name
+              << utf8::console(name)
               << "\" - damaged, found "
               << count
               << " data blocks from several target files."
@@ -1903,7 +1903,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
           {
             #pragma omp critical
             sout << "File: \""
-              << name
+              << utf8::console(name)
               << "\" - found "
               << count
               << " data blocks from several target files."
@@ -1917,7 +1917,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
           {
             #pragma omp critical
             sout << "Target: \""
-              << name
+              << utf8::console(name)
               << "\" - damaged. Found "
               << count
               << " of "
@@ -1933,13 +1933,13 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
 
             #pragma omp critical
             sout << "Target: \""
-              << name
+              << utf8::console(name)
               << "\" - damaged. Found "
               << count
               << " of "
               << sourcefile->GetVerificationPacket()->BlockCount()
               << " data blocks from \""
-              << targetname
+              << utf8::console(targetname)
               << "\"."
               << endl;
           }
@@ -1950,13 +1950,13 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
 
             #pragma omp critical
             sout << "File: \""
-              << name
+              << utf8::console(name)
               << "\" - found "
               << count
               << " of "
               << sourcefile->GetVerificationPacket()->BlockCount()
               << " data blocks from \""
-              << targetname
+              << utf8::console(targetname)
               << "\"."
               << endl;
           }
@@ -1979,7 +1979,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
         if (originalsourcefile == sourcefile)
         {
           #pragma omp critical
-          sout << "Target: \"" << name << "\" - found." << endl;
+          sout << "Target: \"" << utf8::console(name) << "\" - found." << endl;
         }
         // Were we scanning the target file or an extra file
         else if (originalsourcefile != 0)
@@ -1989,9 +1989,9 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
 
           #pragma omp critical
           sout << "Target: \""
-            << name
+            << utf8::console(name)
             << "\" - is a match for \""
-            << targetname
+            << utf8::console(targetname)
             << "\"."
             << endl;
         }
@@ -2002,9 +2002,9 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
 
           #pragma omp critical
           sout << "File: \""
-            << name
+            << utf8::console(name)
             << "\" - is a match for \""
-            << targetname
+            << utf8::console(targetname)
             << "\"."
             << endl;
         }
@@ -2023,7 +2023,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
       {
         #pragma omp critical
         sout << "File: \""
-          << name
+          << utf8::console(name)
           << "\" - found "
           << duplicatecount
           << " duplicate data blocks."
@@ -2033,7 +2033,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
       {
         #pragma omp critical
         sout << "File: \""
-          << name
+          << utf8::console(name)
           << "\" - no data found."
           << endl;
       }
@@ -2743,7 +2743,7 @@ bool Par2Repairer::RemoveBackupFiles(void)
       string name;
       string path;
       DiskFile::SplitFilename((*bf)->FileName(), path, name);
-      sout << "Remove \"" << name << "\"." << endl;
+      sout << "Remove \"" << utf8::console(name) << "\"." << endl;
     }
 
     if ((*bf)->IsOpen())
@@ -2775,7 +2775,7 @@ bool Par2Repairer::RemoveParFiles(void)
         string name;
         string path;
         DiskFile::SplitFilename((*s), path, name);
-        sout << "Remove \"" << name << "\"." << endl;
+        sout << "Remove \"" << utf8::console(name) << "\"." << endl;
       }
 
       if (diskfile->IsOpen())

--- a/src/par2repairersourcefile.cpp
+++ b/src/par2repairersourcefile.cpp
@@ -73,7 +73,7 @@ void Par2RepairerSourceFile::SetVerificationPacket(VerificationPacket *_verifica
 void Par2RepairerSourceFile::ComputeTargetFileName(std::ostream &sout, std::ostream &serr, const NoiseLevel noiselevel, const string &path)
 {
   // Get a version of the filename compatible with the OS
-  string filename = DescriptionPacket::TranslateFilenameFromPar2ToLocal(sout, serr, noiselevel, descriptionpacket->FileName());
+  string filename = DescriptionPacket::TranslateFilenameFromPar2ToLocal(sout, serr, noiselevel, utf8::compatible(descriptionpacket->FileName()));
 
   targetfilename = path + filename;
 }

--- a/src/par2repairersourcefile.cpp
+++ b/src/par2repairersourcefile.cpp
@@ -73,7 +73,7 @@ void Par2RepairerSourceFile::SetVerificationPacket(VerificationPacket *_verifica
 void Par2RepairerSourceFile::ComputeTargetFileName(std::ostream &sout, std::ostream &serr, const NoiseLevel noiselevel, const string &path)
 {
   // Get a version of the filename compatible with the OS
-  string filename = DescriptionPacket::TranslateFilenameFromPar2ToLocal(sout, serr, noiselevel, utf8::compatible(descriptionpacket->FileName()));
+  string filename = DescriptionPacket::TranslateFilenameFromPar2ToLocal(sout, serr, noiselevel, descriptionpacket->FileName());
 
   targetfilename = path + filename;
 }

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -1,0 +1,89 @@
+﻿//  This file is part of par2cmdline (a PAR 2.0 compatible file verification and
+//  repair tool). See http://parchive.sourceforge.net for details of PAR 2.0.
+//
+//  Copyright (c) 2003 Peter Brian Clements
+//  Copyright (c) 2019 Michael D. Nahas
+//
+//  par2cmdline is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  par2cmdline is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#include "utf8.h"
+
+namespace utf8 {
+#if defined(_WIN32) && defined(UNICODE)
+std::string narrow(const std::wstring& wstr, UINT cp)
+{
+	if (wstr.empty()) return std::string();
+	int size_needed = WideCharToMultiByte(cp, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
+	std::string strTo(size_needed, 0);
+	WideCharToMultiByte(cp, 0, &wstr[0], (int)wstr.size(), &strTo[0], size_needed, NULL, NULL);
+	return strTo;
+}
+
+std::string narrow(const std::wstring& wstr)
+{
+	return narrow(wstr, CP_UTF8);
+}
+
+std::wstring widen(const std::string& str)
+{
+	if (str.empty()) return std::wstring();
+	int size_needed = MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), NULL, 0);
+	std::wstring wstrTo(size_needed, 0);
+	MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), &wstrTo[0], size_needed);
+	return wstrTo;
+}
+
+std::string console(const std::string& str)
+{
+	return narrow(widen(str), ::GetConsoleOutputCP());
+}
+
+// Translate PAR filename Extended ASCII to UTF8
+std::string compatible(const std::string& str)
+{
+	int size_needed = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str.c_str(), -1, NULL, 0);
+	if (size_needed != 0)
+	  return str;
+
+	size_needed = MultiByteToWideChar(CP_ACP, MB_ERR_INVALID_CHARS, str.c_str(), -1, NULL, 0);
+	if (size_needed == 0)
+		return str;
+
+	WCHAR* utf8Buffer = new WCHAR[size_needed];
+	MultiByteToWideChar(CP_ACP, 0, str.c_str(), -1, utf8Buffer, size_needed);	
+	size_needed = WideCharToMultiByte(CP_UTF8, 0, utf8Buffer, -1, NULL, 0, NULL, NULL);
+	if (size_needed == 0)
+	{
+		delete[] utf8Buffer;
+		return str;
+	}
+
+	char* utf8Char = new char[size_needed];
+	WideCharToMultiByte(CP_UTF8, 0, utf8Buffer, -1, utf8Char, size_needed, NULL, NULL);
+	std::string strResult(utf8Char);
+
+	delete[] utf8Buffer;
+	delete[] utf8Char;
+
+	return strResult;
+}
+#else
+  std::string narrow(std::string wstr, unsigned int cp) { return wstr; }
+  std::string narrow(std::string wstr) { return wstr; }
+  std::string widen(std::string str) { return str; }
+  std::string console(std::string str) { return str; }
+  std::string compatible(std::string strData) { return strData; }
+#endif
+}

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -49,41 +49,10 @@ std::string console(const std::string& str)
 {
 	return narrow(widen(str), ::GetConsoleOutputCP());
 }
-
-// Translate PAR filename Extended ASCII to UTF8
-std::string compatible(const std::string& str)
-{
-	int size_needed = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str.c_str(), -1, NULL, 0);
-	if (size_needed != 0)
-	  return str;
-
-	size_needed = MultiByteToWideChar(CP_ACP, MB_ERR_INVALID_CHARS, str.c_str(), -1, NULL, 0);
-	if (size_needed == 0)
-		return str;
-
-	WCHAR* utf8Buffer = new WCHAR[size_needed];
-	MultiByteToWideChar(CP_ACP, 0, str.c_str(), -1, utf8Buffer, size_needed);	
-	size_needed = WideCharToMultiByte(CP_UTF8, 0, utf8Buffer, -1, NULL, 0, NULL, NULL);
-	if (size_needed == 0)
-	{
-		delete[] utf8Buffer;
-		return str;
-	}
-
-	char* utf8Char = new char[size_needed];
-	WideCharToMultiByte(CP_UTF8, 0, utf8Buffer, -1, utf8Char, size_needed, NULL, NULL);
-	std::string strResult(utf8Char);
-
-	delete[] utf8Buffer;
-	delete[] utf8Char;
-
-	return strResult;
-}
 #else
   std::string narrow(std::string wstr, unsigned int cp) { return wstr; }
   std::string narrow(std::string wstr) { return wstr; }
   std::string widen(std::string str) { return str; }
   std::string console(std::string str) { return str; }
-  std::string compatible(std::string strData) { return strData; }
 #endif
 }

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -1,0 +1,44 @@
+//  This file is part of par2cmdline (a PAR 2.0 compatible file verification and
+//  repair tool). See http://parchive.sourceforge.net for details of PAR 2.0.
+//
+//  Copyright (c) 2003 Peter Brian Clements
+//  Copyright (c) 2019 Michael D. Nahas
+//
+//  par2cmdline is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  par2cmdline is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+// 
+
+#pragma once
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#include <string>
+
+namespace utf8 {
+#if defined(_WIN32) && defined(UNICODE)
+  std::string narrow(const std::wstring& wstr, UINT cp);
+  std::string narrow(const std::wstring& wstr);
+  std::wstring widen(const std::string& str);
+  std::string console(const std::string& str);
+  std::string compatible(const std::string& strData);
+#else
+  std::string narrow(std::string wstr, unsigned int cp);
+  std::string narrow(std::string wstr);
+  std::string widen(std::string str);
+  std::string console(std::string str);
+  std::string compatible(std::string strData);
+#endif
+}

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -33,12 +33,10 @@ namespace utf8 {
   std::string narrow(const std::wstring& wstr);
   std::wstring widen(const std::string& str);
   std::string console(const std::string& str);
-  std::string compatible(const std::string& strData);
 #else
   std::string narrow(std::string wstr, unsigned int cp);
   std::string narrow(std::string wstr);
   std::string widen(std::string str);
   std::string console(std::string str);
-  std::string compatible(std::string strData);
 #endif
 }


### PR DESCRIPTION
Adds support for Unicode program arguments and long-paths using the `\\?\` prefix on Windows.
Also converts filenames to the codepage in use by the console, so if supported won't result in question marks in the output.

The changes should have no affect on non-Windows builds, the utf8::* methods are no-ops.

References to a few useful resources used to arrive at this solution:
- https://github.com/alf-p-steinbach/C---how-to---make-non-English-text-work-in-Windows/blob/main/how-to-use-utf8-in-windows.md the app-manifest.xml approach could have been useful but it appears to be require Windows 10, hence the wmain wrapper.
- https://utf8everywhere.org

Resolves #189