### PR TITLE
When number of recovery files is set, you get "File already exists"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -107,6 +107,7 @@ EXTRA_DIST = PORTING ROADMAP \
 			 tests/test29 \
 			 tests/test30 \
 			 tests/test31 \
+			 tests/test32 \
 			 tests/unit_tests
 
 
@@ -174,6 +175,7 @@ TESTS = tests/test1 \
 		tests/test29 \
 		tests/test30 \
 		tests/test31 \
+		tests/test32 \
 		tests/unit_tests
 
 install-exec-hook :

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -571,7 +571,7 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
               cerr << "Invalid option: " << argv[0] << endl;
               return false;
             }
-            if (recoveryfilescheme != scUnknown)
+            if (recoveryfilescheme != scUnknown && recoveryfilescheme != scUniform)
             {
               cerr << "Cannot specify two recovery file size schemes." << endl;
               return false;
@@ -656,6 +656,10 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
               return false;
             }
 
+            // When number of recovery files is used, set the recoveryfilescheme
+            // to uniform, since variable will not always be able to fill all
+            // the files
+            recoveryfilescheme = scUniform;
           }
           break;
 

--- a/src/commandline_test.cpp
+++ b/src/commandline_test.cpp
@@ -1139,7 +1139,7 @@ int test10() {
 		    default_extrafiles,
 		    default_blocksize,
 		    default_firstblock,
-		    default_recoveryfilescheme,
+		    scUniform, // when recovery file number is set the scheme is uniform
 		    31,
 		    default_recoveryblockcount)) {
     return 1;

--- a/tests/test32
+++ b/tests/test32
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+execdir="$PWD"
+
+# valgrind tests memory usage.
+# wine allow for windows testing on linux
+if [ -n "${PARVALGRINDOPTS+set}" ]
+then
+    PARBINARY="valgrind $PARVALGRINDOPTS $execdir/par2"
+elif [ "`which wine`" != "" ] && [ -f "$execdir/par2.exe" ]
+then
+    PARBINARY="wine $execdir/par2.exe"
+else
+    PARBINARY="$execdir/par2"
+fi
+
+
+if [ -z "$srcdir" ] || [ "." = "$srcdir" ]; then
+  srcdir="$PWD"
+  TESTDATA="$srcdir/tests"
+else
+  srcdir="$PWD/$srcdir"
+  TESTDATA="$srcdir/tests"
+fi
+
+TESTROOT="$PWD"
+
+testname=$(basename $0)
+rm -f "$testname.log"
+rm -rf "run$testname"
+
+mkdir "run$testname" && cd "run$testname" || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
+
+tar -xzf "$TESTDATA/subdirdata.tar.gz" || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+
+banner="Bug 205, Files already exist so no par2 is created"
+dashes=`echo "$banner" | sed s/./-/g`
+
+echo $dashes
+echo $banner
+echo $dashes
+
+mkdir par2
+
+$PARBINARY create -vv -a par2/disk1.par2 -b32768 -n31 -R -v -B./ * || { echo "ERROR: Recursive creation of PAR 2.0 files failed" ; exit 1; } >&2
+
+$PARBINARY verify -B./ par2/disk1.par2 || { echo "ERROR: verify failed" ; exit 1; } >&2
+
+cd "$TESTROOT"
+rm -rf "run$testname"
+
+exit 0


### PR DESCRIPTION
Cause: default the par2 volumes creation is variable, so the number of blocks in the recovery files is exponentially increased, if you request too many files the needed recovery blocks can't fill the requested number of files.