### PR TITLE
Strip MacOS binary

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -119,6 +119,9 @@ jobs:
     - name: make
       run: make
 
+    - name: strip
+      run: strip par2
+
     - name: Upload binary artifact
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
The Linux binary is [being stripped](https://github.com/Parchive/par2cmdline/blob/620ca05e751f5c145a2d9a837ba91a9a498f0ef4/.github/workflows/build-release.yml#L49) when built.  
For consistency, the MacOS binary should probably also be stripped.