### PR TITLE
Add armhf Linux build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,6 +28,9 @@ jobs:
         - arch: arm64
           configure_host: --host=aarch64-linux-gnu
           xcc: aarch64-linux-gnu-
+        - arch: armhf
+          configure_host: --host=armv7l-linux-gnueabihf
+          xcc: arm-linux-gnueabihf-
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This adds a Linux armhf/armv7 build for 32-bit ARM platforms.

( Requested from https://github.com/animetosho/par2cmdline-turbo/issues/43 )