### PR TITLE
Add SPM support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,55 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+    name: "par2cmdline",
+    products: [
+        .library(
+            name: "par2cmdline",
+            targets: [
+                "par2cmdline",
+            ],
+        ),
+    ],
+    targets: [
+        .target(
+            name: "par2cmdline",
+            path: "src",
+            sources: [
+                "commandline.cpp",
+                "crc.cpp",
+                "creatorpacket.cpp",
+                "criticalpacket.cpp",
+                "datablock.cpp",
+                "descriptionpacket.cpp",
+                "diskfile.cpp",
+                "filechecksummer.cpp",
+                "galois.cpp",
+                "libpar2.cpp",
+                "mainpacket.cpp",
+                "md5.cpp",
+                "par1fileformat.cpp",
+                "par1repairer.cpp",
+                "par1repairersourcefile.cpp",
+                "par2creator.cpp",
+                "par2creatorsourcefile.cpp",
+                "par2fileformat.cpp",
+                "par2repairer.cpp",
+                "par2repairersourcefile.cpp",
+                "recoverypacket.cpp",
+                "reedsolomon.cpp",
+                "utf8.cpp",
+                "verificationhashtable.cpp",
+                "verificationpacket.cpp",
+            ],
+            publicHeadersPath: "",
+            cxxSettings: [
+                .define("NDEBUG"),
+                .define("PACKAGE", to: "\"par2cmdline\""),
+                .define("VERSION", to: "\"1.0.0\""),
+            ],
+        ),
+    ],
+    cxxLanguageStandard: .cxx14,
+)

--- a/src/libpar2.h
+++ b/src/libpar2.h
@@ -70,9 +70,13 @@ typedef signed long long   i64;
 #else // HAVE_CONFIG_H
 
 typedef   unsigned char        u8;
+typedef   signed char          i8;
 typedef   unsigned short       u16;
+typedef   signed short         i16;
 typedef   unsigned int         u32;
+typedef   signed int           i32;
 typedef   unsigned long long   u64;
+typedef   signed long long     i64;
 
 #endif
 #endif


### PR DESCRIPTION
SPM is [Swift Package Manager](https://www.swift.org/documentation/package-manager/).

It's cross-platform (Darwin, Linux, Android, Windows) and it supports Swift, ObjC, C++, C, ...

It's a bit like a CMakeLists.txt, just more restrictive as it runs in a sandbox preventing running commands that could be potentially risky.

I wrote it because on macOS, double-clicking Package.swift will open an Xcode project that can be used for building, analyzing and editing the project, just like the existing `par2cmdline.sln` for Visual Studio.

On the caveats, due to sandboxing, it can't run `./configure`, so it can't generate config.h, so I had to add the missing definitions for `i8`, `i16`, `i32` and `i64` when HAVE_CONFIG_H was not defined.