### PR TITLE
Remove unused code

### DIFF
--- a/src/par2creatorsourcefile.cpp
+++ b/src/par2creatorsourcefile.cpp
@@ -248,8 +248,6 @@ bool Par2CreatorSourceFile::Open(NoiseLevel noiselevel, std::ostream &sout, std:
       verificationpacket->SetBlockHashAndCRC(blocknumber, blockhash, blockcrc);
 
       blocknumber++;
-
-      need = 0;
     }
 
     // Finish computing the file hash.

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -1843,7 +1843,6 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
     {
       #pragma omp critical
       sout << endl;
-      progressline = false;
     }
 
     #pragma omp critical


### PR DESCRIPTION
Xcode analyzer is warning the values `need` and `progressline` are written to but never read afterwards.