### PR TITLE
Reduce the minimum supported macOS version and add a universal macOS binary

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -101,11 +101,14 @@ jobs:
       matrix:
         include:
         - arch: amd64
-          macos_image: macos-13
+          xcxxflags: -arch x86_64 -mmacosx-version-min=10.13
+          configure_host: --host=x86_64-apple-darwin
         - arch: arm64
-          macos_image: macos-latest
+          xcxxflags: -arch arm64
+        - arch: universal
+          xcxxflags: -arch x86_64 -arch arm64 -mmacosx-version-min=10.13
 
-    runs-on: ${{ matrix.macos_image }}
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -117,7 +120,9 @@ jobs:
       run: ./automake.sh
 
     - name: configure
-      run: ./configure
+      run: ./configure ${{ matrix.configure_host }}
+      env:
+        CXXFLAGS: ${{ matrix.xcxxflags }}
 
     - name: make
       run: make

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,6 +19,8 @@ jobs:
     needs:
     - build-check-linux
 
+    name: build-linux (${{ matrix.arch }})
+
     strategy:
       matrix:
         include:
@@ -66,6 +68,8 @@ jobs:
     needs:
     - build-check-windows
 
+    name: build-windows (${{ matrix.name }})
+
     strategy:
       matrix:
         include:
@@ -97,6 +101,8 @@ jobs:
     needs:
     - build-check-macos
 
+    name: build-macos (${{ matrix.arch }})
+
     strategy:
       matrix:
         include:
@@ -104,7 +110,7 @@ jobs:
           xcxxflags: -arch x86_64 -mmacosx-version-min=10.13
           configure_host: --host=x86_64-apple-darwin
         - arch: arm64
-          xcxxflags: -arch arm64
+          xcxxflags: -mmacosx-version-min=11.0
         - arch: universal
           xcxxflags: -arch x86_64 -arch arm64 -mmacosx-version-min=10.13
 


### PR DESCRIPTION
Fixes #225

- Updates macOS build step to use macos-latest
- Renamed build steps, by default it was combining the matrix and they are long and complicated
- Reduced macOS amd64 mininum version 10.13 (High Sierra) so about 2010 hardware
- Added a universal build for macOS (it has the amd64 and arm64 binary in one file), I'm not 100% sure what the minimum macOS it'll run on is. I think it will also work on 10.13 but I'm not able to test it.

The universal build could have just combined the two artifacts `lipo -create -output par2 par2amd par2arm` but that would have been more complicated to setup a workflow for.

