### PR TITLE
Update COPYING with the latest GPL v2 license

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,7 +2,7 @@
                        Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -304,8 +304,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    with this program; if not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -329,8 +328,8 @@ necessary.  Here is a sample; alter the names:
   Yoyodyne, Inc., hereby disclaims all copyright interest in the program
   `Gnomovision' (which makes passes at compilers) written by James Hacker.
 
-  <signature of Ty Coon>, 1 April 1989
-  Ty Coon, President of Vice
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
 
 This General Public License does not permit incorporating your program into
 proprietary programs.  If your program is a subroutine library, you may


### PR DESCRIPTION
While updating the par2cmdline Fedora package, I noticed that `rpmlint` reported the following error:
```
par2cmdline.x86_64: E: incorrect-fsf-address /usr/share/licenses/par2cmdline/COPYING
```

In this PR, I've updated par2cmdline to use the latest GPL v2 license file available at:
https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt

Nothing changes expect for the removal of the no longer valid FSF postal address and replacement with a pointer to their web site.