### PR TITLE
Enable par2.exe to utilize a text file as the source of files to process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # par2cmdline
 
 **Difference Between this Version and Main Branch**
+
 This fork provides the capacity to utilize the paramter @filelist.txt to input a list of specific files.
  eg. par2.exe c -t8 -m2048 -B. -s1048576 L:\integrity_check\logs\recovery_data.par2 @L:\integrity_check\logs\files.txt
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # par2cmdline
 
+# Difference Between this Version and Main Branch
+This fork provides the capacity to utilize the paramter @filelist.txt to input a list of specific files.
+# eg.
+par2.exe c -t8 -m2048 -B. -s1048576 L:\integrity_check\logs\recovery_data.par2 @L:\integrity_check\logs\files.txt
+
+
 **par2cmdline** is a PAR 2.0 compatible file verification and repair tool.
 
 To see the ongoing development see: <https://github.com/parchive/par2cmdline>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # par2cmdline
 
-# Difference Between this Version and Main Branch
+** Difference Between this Version and Main Branch **
 This fork provides the capacity to utilize the paramter @filelist.txt to input a list of specific files.
-# eg.
-par2.exe c -t8 -m2048 -B. -s1048576 L:\integrity_check\logs\recovery_data.par2 @L:\integrity_check\logs\files.txt
+ eg. par2.exe c -t8 -m2048 -B. -s1048576 L:\integrity_check\logs\recovery_data.par2 @L:\integrity_check\logs\files.txt
 
 
 **par2cmdline** is a PAR 2.0 compatible file verification and repair tool.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # par2cmdline
 
-** Difference Between this Version and Main Branch **
+**Difference Between this Version and Main Branch**
 This fork provides the capacity to utilize the paramter @filelist.txt to input a list of specific files.
  eg. par2.exe c -t8 -m2048 -B. -s1048576 L:\integrity_check\logs\recovery_data.par2 @L:\integrity_check\logs\files.txt
 

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -860,9 +860,16 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
           }
         }
       } 
-      //START SECTION FOR ADDING @FILELIST FUNCTIONALITY
+//START SECTION FOR ADDING @FILELIST FUNCTIONALITY
       else if (argv[0][0] == '@') // Handle list files
       {
+        // 1. Check if the '@' is followed by a filename
+        if (argv[0][1] == '\0')
+        {
+          std::cerr << "No filename specified after '@' symbol." << std::endl;
+          return false;
+        }
+
         std::ifstream listfile(&argv[0][1]);
         if (!listfile.is_open())
         {
@@ -873,17 +880,21 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
         std::string line;
         while (std::getline(listfile, line))
         {
-          if (line.empty()) continue;
+          // 2. Trim whitespace or skip whitespace-only lines
+          // This finds the first non-whitespace character
+          size_t first = line.find_first_not_of(" \t\r\n");
+          if (first == std::string::npos) 
+            continue; // Line is empty or only whitespace
+
+          // 3. Removed the 'parfilename.length() == 0' block.
+          // All files in the list are now treated as source files.
           
-          if (parfilename.length() == 0)
+          std::string lpath, lname;
+          DiskFile::SplitFilename(line, lpath, lname);
+          std::unique_ptr<std::list<std::string>> filenames(DiskFile::FindFiles(lpath, lname, recursive));
+          
+          if (filenames)
           {
-            if (!SetParFilename(line)) return false;
-          }
-          else
-          {
-            std::string lpath, lname;
-            DiskFile::SplitFilename(line, lpath, lname);
-            std::unique_ptr<std::list<std::string>> filenames(DiskFile::FindFiles(lpath, lname, recursive));
             for (auto const& fn : *filenames)
             {
               rawfilenames.push_back(DiskFile::GetCanonicalPathname(fn));
@@ -891,6 +902,7 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
           }
         }
       }  //END SECTION FOR ADDING @filelist FUNCTIONALITY
+	  
       else if (parfilename.length() == 0)
       {
         std::string filename = argv[0];

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -22,7 +22,7 @@
 #include<iostream>
 #include<algorithm>
 #include "commandline.h"
-
+#include <fstream>  //ADDED for @FILELIST FUNCTIONALY
 
 #ifdef _MSC_VER
 #ifdef _DEBUG
@@ -139,7 +139,11 @@ void CommandLine::usage(void)
     "  -l       : Limit size of recovery files (don't use both -u and -l)\n"
     "  -n<n>    : Number of recovery files (max 31) (don't use both -n and -l)\n"
     "  -R       : Recurse into subdirectories\n"
-    "             (Be aware of wildcard shell expansion)\n"
+	"             (Be aware of wildcard shell expansion)\n"
+	"   @       : Process a listing of files specified in a text file \n"
+	"             (eg. @filelist.txt) \n"
+
+    
     "\n";
   std::cout <<
     "Example:\n"
@@ -289,10 +293,11 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
   {
     if (argv[0][0])
     {
-      if (options && argv[0][0] != '-')
+    //MODIFIED FOR @FILELIST FUNCTIONALITY
+      if (options && argv[0][0] != '-' && argv[0][0] != '@')
         options = false;
-
-      if (options)
+    //MODIFIED FOR @FILELIST FUNCTIONALITY
+      if (options && argv[0][0] == '-')
       {
         switch (argv[0][1])
         {
@@ -854,7 +859,38 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
             return false;
           }
         }
-      }
+      } 
+      //START SECTION FOR ADDING @FILELIST FUNCTIONALITY
+      else if (argv[0][0] == '@') // Handle list files
+      {
+        std::ifstream listfile(&argv[0][1]);
+        if (!listfile.is_open())
+        {
+          std::cerr << "Could not open list file: " << &argv[0][1] << std::endl;
+          return false;
+        }
+
+        std::string line;
+        while (std::getline(listfile, line))
+        {
+          if (line.empty()) continue;
+          
+          if (parfilename.length() == 0)
+          {
+            if (!SetParFilename(line)) return false;
+          }
+          else
+          {
+            std::string lpath, lname;
+            DiskFile::SplitFilename(line, lpath, lname);
+            std::unique_ptr<std::list<std::string>> filenames(DiskFile::FindFiles(lpath, lname, recursive));
+            for (auto const& fn : *filenames)
+            {
+              rawfilenames.push_back(DiskFile::GetCanonicalPathname(fn));
+            }
+          }
+        }
+      }  //END SECTION FOR ADDING @filelist FUNCTIONALITY
       else if (parfilename.length() == 0)
       {
         std::string filename = argv[0];
@@ -884,7 +920,7 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
           ++fn;
         }
 
-        // delete filenames;   Taken care of by unique_ptr<>
+       // delete filenames;   Taken care of by unique_ptr<>
       }
     }
 


### PR DESCRIPTION
I require par2.exe to accommodate processing files stored in a text file.  My patch to facilitate this this functionality are in the commandline.cpp file. I have converted the Windows CR/LF to /LF so hopefully my version of this file will work properly with github. 

Thank
sussjb99.