### PR TITLE
Take input files from stdin (standard input)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -164,6 +164,10 @@ EXTRA_DIST = \
 			 tests/test38.ps1 \
 			 tests/test39 \
 			 tests/test39.ps1 \
+       tests/test40 \
+       tests/test40.ps1 \
+       tests/test41 \
+       tests/test41.ps1 \
 			 tests/unit_tests \
 			 tests/unit_tests.ps1
 
@@ -243,6 +247,8 @@ TESTS = tests/test1 \
 		tests/test37 \
 		tests/test38 \
 		tests/test39 \
+    tests/test40 \
+    tests/test41 \
 		tests/utf8_test \
 		tests/unit_tests
 

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -140,8 +140,8 @@ void CommandLine::usage(void)
     "  -n<n>    : Number of recovery files (max 31) (don't use both -n and -l)\n"
     "  -R       : Recurse into subdirectories\n"
     "             (Be aware of wildcard shell expansion)\n"
-    "   @       : Process a listing of files specified in a text file \n"
-    "             (eg. @filelist.txt) \n"
+    "   @       : Process a listing of files specified in text (file) input \n"
+    "             (eg. @filelist.txt, or bare @ to read from stdin) \n"
     "\n";
   std::cout <<
     "Example:\n"
@@ -861,22 +861,28 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
 //START SECTION FOR ADDING @FILELIST FUNCTIONALITY
       else if (argv[0][0] == '@') // Handle list files
       {
+        std::istream* input = nullptr;
+        std::ifstream listfile;
+
         // 1. Check if the '@' is followed by a filename
         if (argv[0][1] == '\0')
         {
-          std::cerr << "No filename specified after '@' symbol." << std::endl;
-          return false;
+          // Bare '@' - read filelist from stdin
+          input = &std::cin;
         }
-
-        std::ifstream listfile(&argv[0][1]);
-        if (!listfile.is_open())
+        else
         {
-          std::cerr << "Could not open list file: " << &argv[0][1] << std::endl;
-          return false;
+          listfile.open(&argv[0][1]);
+          if (!listfile.is_open())
+          {
+            std::cerr << "Could not open list file: " << &argv[0][1] << std::endl;
+            return false;
+          }
+          input = &listfile;
         }
 
         std::string line;
-        while (std::getline(listfile, line))
+        while (std::getline(*input, line))
         {
           // 2. Trim whitespace or skip whitespace-only lines
           // This finds the first non-whitespace character

--- a/tests/test40
+++ b/tests/test40
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+execdir="$PWD"
+
+# valgrind tests memory usage.
+# wine allow for windows testing on linux
+if [ -n "${PARVALGRINDOPTS+set}" ]
+then
+    PARBINARY="valgrind $PARVALGRINDOPTS $execdir/par2"
+elif [ "`which wine`" != "" ] && [ -f "$execdir/par2.exe" ]
+then
+    PARBINARY="wine $execdir/par2.exe"
+else
+    PARBINARY="$execdir/par2"
+fi
+
+
+if [ -z "$srcdir" ] || [ "." = "$srcdir" ]; then
+  srcdir="$PWD"
+  TESTDATA="$srcdir/tests"
+else
+  srcdir="$PWD/$srcdir"
+  TESTDATA="$srcdir/tests"
+fi
+
+TESTROOT="$PWD"
+
+testname=$(basename $0)
+rm -f "$testname.log"
+rm -rf "run$testname"
+
+mkdir "run$testname" && cd "run$testname" || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
+
+tar -xzf "$TESTDATA/flatdata.tar.gz" || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+
+banner="Testing flat data par2 creation with filelist from stdin"
+dashes=`echo "$banner" | sed s/./-/g`
+
+echo $dashes
+echo $banner
+echo $dashes
+
+cat "$TESTDATA/flatdata-filelist.txt" | $PARBINARY c recovery.par2 @ || { echo "ERROR: failed to create parchive from stdin filelist" ; exit 1; } >&2
+$PARBINARY v recovery.par2 || { echo "ERROR: failed to verify parchive created from stdin filelist" ; exit 1; } >&2
+
+echo "Successfully created and verified par2 recovery with filelist from stdin"
+
+cd "$TESTROOT"
+rm -rf "run$testname"
+
+exit 0

--- a/tests/test40.ps1
+++ b/tests/test40.ps1
@@ -1,0 +1,35 @@
+#!/usr/bin/env pwsh
+# Test 40: Take file list on stdin
+
+$ErrorActionPreference = "Stop"
+
+. (Join-Path $PSScriptRoot "testfuncs.ps1")
+
+$testname = [System.IO.Path]::GetFileNameWithoutExtension($MyInvocation.MyCommand.Name)
+
+try {
+    Initialize-Test -TestName $testname
+
+    Expand-TarGz -Archive (Join-Path $TESTDATA "flatdata.tar.gz") -Destination "."
+
+    Write-Banner "Testing flat data par2 creation with filelist from stdin"
+
+    $exitCode = Get-Content (Join-Path $TESTDATA "flatdata-filelist.txt") | Invoke-Par2 -Arguments @("c", "recovery.par2", "@")
+    if ($exitCode -ne 0) {
+      Exit-TestWithError "failed to create parchive from stdin filelist"
+    }
+
+    $exitCode = Invoke-Par2 -Arguments @("r", "recovery.par2")
+    if ($exitCode -ne 0) {
+      Exit-TestWithError "failed to verify parchive created from stdin filelist"
+    }
+
+    Write-Host "Successfully created and verified par2 recovery with filelist from stdin"
+    Complete-Test
+    exit 0
+}
+catch {
+    Write-Host "ERROR: $_" -ForegroundColor Red
+    Complete-Test
+    exit 1
+}

--- a/tests/test41
+++ b/tests/test41
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+execdir="$PWD"
+
+# valgrind tests memory usage.
+# wine allow for windows testing on linux
+if [ -n "${PARVALGRINDOPTS+set}" ]
+then
+    PARBINARY="valgrind $PARVALGRINDOPTS $execdir/par2"
+elif [ "`which wine`" != "" ] && [ -f "$execdir/par2.exe" ]
+then
+    PARBINARY="wine $execdir/par2.exe"
+else
+    PARBINARY="$execdir/par2"
+fi
+
+
+if [ -z "$srcdir" ] || [ "." = "$srcdir" ]; then
+  srcdir="$PWD"
+  TESTDATA="$srcdir/tests"
+else
+  srcdir="$PWD/$srcdir"
+  TESTDATA="$srcdir/tests"
+fi
+
+TESTROOT="$PWD"
+
+testname=$(basename $0)
+rm -f "$testname.log"
+rm -rf "run$testname"
+
+mkdir "run$testname" && cd "run$testname" || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
+
+tar -xzf "$TESTDATA/subdirdata.tar.gz" || { echo "ERROR: Could not extract data test files" ; exit 1; } >&2
+
+banner="Testing subdir data par2 creation with mixed files and stdin filelist"
+dashes=`echo "$banner" | sed s/./-/g`
+
+echo $dashes
+echo $banner
+echo $dashes
+
+cat "$TESTDATA/subdirdata-partial-filelist.txt" | $PARBINARY c recovery.par2 subdir1/test-6.data subdir2/test-7.data @ || { echo "ERROR: failed to create parchive from stdin filelist" ; exit 1; } >&2
+$PARBINARY v recovery.par2 || { echo "ERROR: failed to verify parchive created from stdin filelist" ; exit 1; } >&2
+
+echo "Successfully created and verified par2 recovery with filelist from stdin"
+
+cd "$TESTROOT"
+rm -rf "run$testname"
+
+exit 0

--- a/tests/test41.ps1
+++ b/tests/test41.ps1
@@ -1,0 +1,35 @@
+#!/usr/bin/env pwsh
+# Test 41: Take file list on stdin in combination with files on command-line
+
+$ErrorActionPreference = "Stop"
+
+. (Join-Path $PSScriptRoot "testfuncs.ps1")
+
+$testname = [System.IO.Path]::GetFileNameWithoutExtension($MyInvocation.MyCommand.Name)
+
+try {
+    Initialize-Test -TestName $testname
+
+    Expand-TarGz -Archive (Join-Path $TESTDATA "subdirdata.tar.gz") -Destination "."
+
+    Write-Banner "Testing subdir data par2 creation with mixed files and stdin filelist"
+
+    $exitCode = Get-Content (Join-Path $TESTDATA "subdirdata-partial-filelist.txt") | Invoke-Par2 -Arguments @("c", "recovery.par2", "subdir1\test-6.data", "subdir2\test-7.data", "@")
+    if ($exitCode -ne 0) {
+      Exit-TestWithError "failed to create parchive from stdin filelist"
+    }
+
+    $exitCode = Invoke-Par2 -Arguments @("r", "recovery.par2")
+    if ($exitCode -ne 0) {
+      Exit-TestWithError "failed to verify parchive created from stdin filelist"
+    }
+
+    Write-Host "Successfully created and verified par2 recovery with filelist from stdin"
+    Complete-Test
+    exit 0
+}
+catch {
+    Write-Host "ERROR: $_" -ForegroundColor Red
+    Complete-Test
+    exit 1
+}


### PR DESCRIPTION
This extends upon #273 and #279.

I always missed this in par2cmdline and since the logic is already in place,
it would now be nice to use the error-case where `@` is followed by nothing
for taking the input from standard input, arguably a common Linux use-case.

This would allow for setups like:
```
desertwitch@vDebianDev:~/par2cmdline$ cat test.txt | ./par2 c test.par2 @
Block size: 16
Source file count: 2
Source block count: 1506
Recovery block count: 75
Recovery file count: 7

Opening: README.md
Opening: ROADMAP
Computing Reed Solomon matrix.
Constructing: done.
Wrote 1200 bytes to disk
Writing recovery packets
Writing verification packets
Done
```

And especially use in shell-scripting feeding other command's output into par2cmdline.