### PR TITLE
fix: input file count over 2000 failing with defaults + edge case

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -173,6 +173,7 @@ EXTRA_DIST = \
        tests/test42 \
        tests/test42.ps1 \
        tests/test43 \
+       tests/test44 \
 			 tests/unit_tests \
 			 tests/unit_tests.ps1
 
@@ -256,6 +257,7 @@ TESTS = tests/test1 \
     tests/test41 \
     tests/test42 \
     tests/test43 \
+    tests/test44 \
 		tests/utf8_test \
 		tests/unit_tests
 

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -175,6 +175,12 @@ bool CommandLine::Parse(int argc, const char * const *argv)
       }
     }
 
+    if (sourceblockcount > 32768)
+    {
+      std::cerr << "Too many source blocks (" << sourceblockcount << " > 32768)." << std::endl;
+      return false;
+    }
+
     if (!ComputeRecoveryBlockCount(&recoveryblockcount,
 				   sourceblockcount,
 				   blocksize,

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -1186,11 +1186,28 @@ bool CommandLine::CheckValuesAndSetDefaults() {
       return false;
     }
 
-    // If neither block count not block size is specified
+    // If neither block count nor block size is specified, derive a default
+    // block size from total source data, targeting ~2000 blocks (as previous
+    // default). This replaces the old hard-coded blockcount=2000 which failed
+    // when file count exceeded 2000, and avoids inflated block sizes when file
+    // sizes vary widely. The minimum is clamped so that the total source block
+    // count stays within the PAR2 limit of 32768.
     if (blockcount == 0 && blocksize == 0)
     {
-      // Use a block count of 2000
-      blockcount = 2000;
+        u64 totalsize = 0;
+        for (auto &f : extrafiles)
+            totalsize += filesize_cache.get(f);
+
+        blocksize = (totalsize + 1999) / 2000; // 2000 = target (previous default)
+        blocksize = std::max(blocksize, (u64)4);
+        blocksize = (blocksize + 3) & ~3;
+
+        u64 minblocksize = (totalsize + 32767) / 32768; // 32768 = maximum PAR2
+        minblocksize = (minblocksize + 3) & ~3;
+        minblocksize = std::max(minblocksize, (u64)4);
+
+        if (blocksize < minblocksize)
+            blocksize = minblocksize;
     }
 
     // If no recovery file size scheme is specified then use Variable

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -1203,8 +1203,8 @@ bool CommandLine::CheckValuesAndSetDefaults() {
         blocksize = (blocksize + 3) & ~3;
 
         u64 minblocksize = (totalsize + 32767) / 32768; // 32768 = maximum PAR2
-        minblocksize = (minblocksize + 3) & ~3;
         minblocksize = std::max(minblocksize, (u64)4);
+        minblocksize = (minblocksize + 3) & ~3;
 
         if (blocksize < minblocksize)
             blocksize = minblocksize;

--- a/tests/test44
+++ b/tests/test44
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+execdir="$PWD"
+
+# valgrind tests memory usage.
+# wine allow for windows testing on linux
+if [ -n "${PARVALGRINDOPTS+set}" ]
+then
+    PARBINARY="valgrind $PARVALGRINDOPTS $execdir/par2"
+elif [ "`which wine`" != "" ] && [ -f "$execdir/par2.exe" ]
+then
+    PARBINARY="wine $execdir/par2.exe"
+else
+    PARBINARY="$execdir/par2"
+fi
+
+if [ -z "$srcdir" ] || [ "." = "$srcdir" ]; then
+  srcdir="$PWD"
+  TESTDATA="$srcdir/tests"
+else
+  srcdir="$PWD/$srcdir"
+  TESTDATA="$srcdir/tests"
+fi
+
+TESTROOT="$PWD"
+
+testname=$(basename $0)
+rm -f "$testname.log"
+rm -rf "run$testname"
+
+mkdir "run$testname" && cd "run$testname" || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
+
+banner="par2 create works with more than 2000 input files"
+dashes=`echo "$banner" | sed s/./-/g`
+echo $dashes
+echo $banner
+echo $dashes
+
+# Generate 2001 non-empty data files (each 512 bytes).
+# The old hard-coded blockcount=2000 default would fail here because the
+# number of source files exceeded the block count.
+datadir="$TESTROOT/run$testname/manyfiles"
+mkdir -p "$datadir" || { echo "ERROR: Could not create data directory" ; exit 1; } >&2
+
+i=0
+while [ $i -lt 2001 ]; do
+    printf '%0512d' $i > "$datadir/file_$(printf '%04d' $i).data"
+    i=$((i + 1))
+done
+
+$PARBINARY c -B"$datadir" "$datadir"/test.par2 "$datadir"/*.data || { echo "ERROR: create with >2000 files failed" ; exit 1; } >&2
+
+cd "$TESTROOT"
+rm -rf "run$testname"
+
+exit 0


### PR DESCRIPTION
When no `-b` or `-s` is specified (as is commonly the case when giving no size/count arguments to `par2 create`), the hard-coded default of `blockcount=2000` fails with more than 2000 input source files. This patch fixes that issue, calculating the defaults directly from the total source data (size), while targeting the same ~2000 block granularity as before. This means the issue is resolved with existing behavior for <= 2000 files remaining unchanged. The block size floor (for the calculated default) is clamped to keep the total source block count within the PAR2 limit of 32768.

It also fixes an edge case where widely varying file sizes (one large file among many small files) could inflate block size to match the largest file, causing recovery data to grow far beyond the expected redundancy percentage.

Tested, compiles clean and without warnings while also passing test suite.