### PR TITLE
Fix macOS unoptimised builds

### DIFF
--- a/.github/workflows/build-check-freebsd.yml
+++ b/.github/workflows/build-check-freebsd.yml
@@ -21,6 +21,6 @@ jobs:
           sudo pkg install -y autoconf automake libtool
           ./automake.sh
           ./configure
-          make
+          make -j"$(nproc)"
           make check
           make distcheck

--- a/.github/workflows/build-check-linux.yml
+++ b/.github/workflows/build-check-linux.yml
@@ -15,6 +15,6 @@ jobs:
       run: |
         ./automake.sh
         ./configure
-        make
+        make -j"$(nproc)"
         make check
         make distcheck

--- a/.github/workflows/build-check-macos.yml
+++ b/.github/workflows/build-check-macos.yml
@@ -18,6 +18,6 @@ jobs:
       run: |
         ./automake.sh
         ./configure
-        make
+        make -j"$(sysctl -n hw.ncpu)"
         make check
         make distcheck

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -117,11 +117,8 @@ jobs:
         include:
         - arch: amd64
           xcxxflags: -arch x86_64 -mmacosx-version-min=10.13
-          configure_host: --host=x86_64-apple-darwin
         - arch: arm64
-          xcxxflags: -mmacosx-version-min=11.0
-        - arch: universal
-          xcxxflags: -arch x86_64 -arch arm64 -mmacosx-version-min=10.13
+          xcxxflags: -arch arm64 -mmacosx-version-min=11.0
 
     runs-on: macos-latest
 
@@ -131,12 +128,15 @@ jobs:
     - name: prepare
       run: brew install automake
 
+    # NOTE: setting CFLAGS/CXXFLAGS suppresses autoconf's default "-g -O2",
+    # so -O2 must be passed explicitly or the build ends up unoptimised.
     - name: Build
       env:
-        CXXFLAGS: ${{ matrix.xcxxflags }}
+        CFLAGS: -O2 ${{ matrix.xcxxflags }}
+        CXXFLAGS: -O2 ${{ matrix.xcxxflags }}
       run: |
         ./automake.sh
-        ./configure ${{ matrix.configure_host }}
+        ./configure
         make
         strip par2
 
@@ -144,6 +144,34 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: par2cmdline-macos-${{ matrix.arch }}
+        path: |
+          par2
+        retention-days: 5
+
+  build-macos-universal:
+    needs:
+    - build-macos
+
+    runs-on: macos-latest
+
+    steps:
+    - name: Download slices
+      uses: actions/download-artifact@v7
+      with:
+        pattern: par2cmdline-macos-*
+
+    - name: Create universal binary
+      run: |
+        lipo -create \
+          par2cmdline-macos-amd64/par2 \
+          par2cmdline-macos-arm64/par2 \
+          -output par2
+        lipo -info par2
+
+    - name: Upload binary artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: par2cmdline-macos-universal
         path: |
           par2
         retention-days: 5

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -209,7 +209,7 @@ jobs:
           sudo pkg install -y autoconf automake libtool
           ./automake.sh
           ./configure
-          make
+          make -j"$(nproc)"
           strip par2
 
     - name: Upload binary artifact

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -132,8 +132,8 @@ jobs:
     # so -O2 must be passed explicitly or the build ends up unoptimised.
     - name: Build
       env:
-        CFLAGS: -O2 ${{ matrix.xcxxflags }}
-        CXXFLAGS: -O2 ${{ matrix.xcxxflags }}
+        CFLAGS: -O3 ${{ matrix.xcxxflags }}
+        CXXFLAGS: -O3 ${{ matrix.xcxxflags }}
       run: |
         ./automake.sh
         ./configure

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -63,7 +63,7 @@ jobs:
       run: |
         ./automake.sh
         ./configure ${{ matrix.configure_host }}
-        make
+        make -j"$(nproc)"
 
     - name: Upload binary artifact
       uses: actions/upload-artifact@v7
@@ -137,7 +137,7 @@ jobs:
       run: |
         ./automake.sh
         ./configure
-        make
+        make -j"$(sysctl -n hw.ncpu)"
         strip par2
 
     - name: Upload binary artifact

--- a/libpar2.vcxproj
+++ b/libpar2.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/par2cmdline.vcxproj
+++ b/par2cmdline.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/tests/commandline_test.vcxproj
+++ b/tests/commandline_test.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/tests/crc_test.vcxproj
+++ b/tests/crc_test.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/tests/criticalpacket_test.vcxproj
+++ b/tests/criticalpacket_test.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/tests/descriptionpacket_test.vcxproj
+++ b/tests/descriptionpacket_test.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/tests/diskfile_test.vcxproj
+++ b/tests/diskfile_test.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/tests/galois_test.vcxproj
+++ b/tests/galois_test.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/tests/letype_test.vcxproj
+++ b/tests/letype_test.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/tests/libpar2_test.vcxproj
+++ b/tests/libpar2_test.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/tests/md5_test.vcxproj
+++ b/tests/md5_test.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/tests/reedsolomon_test.vcxproj
+++ b/tests/reedsolomon_test.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/tests/utf8_test.vcxproj
+++ b/tests/utf8_test.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
Currently the macOS builds are scalar only so very slow.

Autoconf only injects its default `-g -O2` when CXXFLAGS is unset, so because env is set we end up with unoptimised builds. 

The universal matrix also drops all ARM SIMD because of `-arch x86_64 -arch arm64`, the solution is to build them separately and use `lipo` to turn them into a universal binary.

I went with `-O3` but it should probably be updated throughout.
I didn't add `-g` because we strip them immediately afterwords, so I wasn't sure if it would do anything.

Any opinion on updating the build tooling to CMAKE?

---

Unrelated changes:

`make -j"$(nproc)"` speed up the builds a little
`<PlatformToolset>v145</PlatformToolset>` because windows-latest has changed and doesn't have v143

---

Identified:

I believe the Windows tests especially are slow because printing to the console every 0.1% is slow, I'll send another PR after that throttles it and fixes some issues - it cut 5 minutes off the Windows test time