### PR TITLE
Printing performance tweaks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,7 @@ libpar2_a_SOURCES = src/crc.cpp src/crc.h \
 	src/par2fileformat.cpp src/par2fileformat.h \
 	src/par2repairer.cpp src/par2repairer.h \
 	src/par2repairersourcefile.cpp src/par2repairersourcefile.h \
+	src/progressmeter.h \
 	src/recoverypacket.cpp src/recoverypacket.h \
 	src/reedsolomon.cpp src/reedsolomon.h \
 	src/verificationhashtable.cpp src/verificationhashtable.h \

--- a/libpar2.vcxproj
+++ b/libpar2.vcxproj
@@ -103,6 +103,7 @@
     <ClInclude Include="src\par2fileformat.h" />
     <ClInclude Include="src\par2repairer.h" />
     <ClInclude Include="src\par2repairersourcefile.h" />
+    <ClInclude Include="src\progressmeter.h" />
     <ClInclude Include="src\recoverypacket.h" />
     <ClInclude Include="src\reedsolomon.h" />
     <ClInclude Include="src\verificationhashtable.h" />

--- a/libpar2.vcxproj.filters
+++ b/libpar2.vcxproj.filters
@@ -146,6 +146,9 @@
     <ClInclude Include="src\par2repairersourcefile.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\progressmeter.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="src\recoverypacket.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -79,18 +79,18 @@ void CommandLine::showversion(void)
 
 void CommandLine::banner(void)
 {
-  std::cout << "Copyright (C) 2003-2015 Peter Brian Clements." << std::endl
-    << "Copyright (C) 2011-2012 Marcel Partap." << std::endl
-    << "Copyright (C) 2012-2026 Ike Devolder." << std::endl
-    << "Copyright (C) 2014-2017 Jussi Kansanen." << std::endl
-    << "Copyright (C) 2019 Michael Nahas." << std::endl
-    << std::endl
-    << "par2cmdline comes with ABSOLUTELY NO WARRANTY." << std::endl
-    << std::endl
-    << "This is free software, and you are welcome to redistribute it and/or modify" << std::endl
-    << "it under the terms of the GNU General Public License as published by the" << std::endl
-    << "Free Software Foundation; either version 2 of the License, or (at your" << std::endl
-    << "option) any later version. See COPYING for details." << std::endl
+  std::cout << "Copyright (C) 2003-2015 Peter Brian Clements.\n"
+    "Copyright (C) 2011-2012 Marcel Partap.\n"
+    "Copyright (C) 2012-2026 Ike Devolder.\n"
+    "Copyright (C) 2014-2017 Jussi Kansanen.\n"
+    "Copyright (C) 2019 Michael Nahas.\n"
+    "\n"
+    "par2cmdline comes with ABSOLUTELY NO WARRANTY.\n"
+    "\n"
+    "This is free software, and you are welcome to redistribute it and/or modify\n"
+    "it under the terms of the GNU General Public License as published by the\n"
+    "Free Software Foundation; either version 2 of the License, or (at your\n"
+    "option) any later version. See COPYING for details.\n"
     << std::endl;
 }
 
@@ -231,7 +231,7 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
       else if (argv[0] == std::string("-VV"))
       {
 	showversion();
-	std::cout << std::endl;
+	std::cout << '\n';
 	banner();
 	return true;
       }

--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -97,7 +97,7 @@ bool DiskFile::CreateParentDirectory(std::string _pathname)
     {
       DWORD error = ::GetLastError();
 
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Could not create the " << path << " directory: " << ErrorMessage(error) << std::endl;
 
       return false;
@@ -125,7 +125,7 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
   {
     DWORD error = ::GetLastError();
 
-    #pragma omp critical
+    #pragma omp critical(stdio)
     *serr << "Could not create \"" << _filename << "\": " << ErrorMessage(error) << std::endl;
 
     return false;
@@ -142,7 +142,7 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
     {
       DWORD error = ::GetLastError();
 
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Could not set size of \"" << _filename << "\": " << ErrorMessage(error) << std::endl;
 
       ::CloseHandle(hFile);
@@ -157,7 +157,7 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
     {
       DWORD error = ::GetLastError();
 
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Could not set size of \"" << _filename << "\": " << ErrorMessage(error) << std::endl;
 
       ::CloseHandle(hFile);
@@ -191,7 +191,7 @@ bool DiskFile::Write(u64 _offset, const void *buffer, size_t length, LengthType 
     {
       DWORD error = ::GetLastError();
 
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Could not write " << (u64)length << " bytes to \"" << filename << "\" at offset " << _offset << ": " << ErrorMessage(error) << std::endl;
 
       return false;
@@ -214,7 +214,7 @@ bool DiskFile::Write(u64 _offset, const void *buffer, size_t length, LengthType 
     {
       DWORD error = ::GetLastError();
 
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Could not write " << write << " bytes to \"" << filename << "\" at offset " << _offset << ": " << ErrorMessage(error) << std::endl;
 
       return false;
@@ -222,7 +222,7 @@ bool DiskFile::Write(u64 _offset, const void *buffer, size_t length, LengthType 
 
     if (wrote != write)
     {
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "INFO: Incomplete write to \"" << filename << "\" at offset " << _offset << ".  Expected to write " << write << " bytes and wrote " << wrote << " bytes." << std::endl;
     }
 
@@ -260,7 +260,7 @@ bool DiskFile::Open(const std::string &_filename, u64 _filesize)
     case ERROR_PATH_NOT_FOUND:
       break;
     default:
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Could not open \"" << _filename << "\": " << ErrorMessage(error) << std::endl;
     }
 
@@ -290,7 +290,7 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxleng
     {
       DWORD error = ::GetLastError();
 
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Could not read " << (u64)length << " bytes from \"" << filename << "\" at offset " << _offset << ": " << ErrorMessage(error) << std::endl;
 
       return false;
@@ -312,7 +312,7 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxleng
     {
       DWORD error = ::GetLastError();
 
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Could not read " << (u64)length << " bytes from \"" << filename << "\" at offset " << _offset << ": " << ErrorMessage(error) << std::endl;
 
       return false;
@@ -320,7 +320,7 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxleng
 
     if (want != got)
     {
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Incomplete read from \"" << filename << "\" at offset " << offset << ".  Tried to read " << want << " bytes and received " << got << " bytes." << std::endl;
     }
 
@@ -496,7 +496,7 @@ bool DiskFile::CreateParentDirectory(std::string _pathname)
 
     if (mkdir(path.c_str(), S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH))
     {
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Could not create the " << path << " directory: " << strerror(errno) << std::endl;
       return false;
     }
@@ -518,7 +518,7 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
 
   if (_filesize > (u64)MaxOffset)
   {
-    #pragma omp critical
+    #pragma omp critical(stdio)
     *serr << "Requested file size for " << _filename << " is too large." << std::endl;
     return false;
   }
@@ -526,7 +526,7 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
   int fd = open(_filename.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
   if (fd < 0)
   {
-    #pragma omp critical
+    #pragma omp critical(stdio)
     *serr << "Could not create " << _filename << ": " << strerror(errno) << std::endl;
 
     return false;
@@ -540,7 +540,7 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
     ::remove(filename.c_str());
     errno = savederrno;
 
-    #pragma omp critical
+    #pragma omp critical(stdio)
     *serr << "Could not create " << _filename << ": " << strerror(errno) << std::endl;
 
     return false;
@@ -550,7 +550,7 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
   {
     if (fseek(file, (OffsetType)_filesize-1, SEEK_SET))
     {
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Could not set end of file of " << _filename << ": " << strerror(errno) << std::endl;
 
       fclose(file);
@@ -561,7 +561,7 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
 
     if (1 != fwrite(&_filesize, 1, 1, file))
     {
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Could not set end of file of " << _filename << ": " << strerror(errno) << std::endl;
 
       fclose(file);
@@ -587,7 +587,7 @@ bool DiskFile::Write(u64 _offset, const void *buffer, size_t length, LengthType 
   {
     if (_offset > (u64)MaxOffset)
     {
-        #pragma omp critical
+        #pragma omp critical(stdio)
         *serr << "Could not write " << (u64)length << " bytes to " << filename << " at offset " << _offset << std::endl;
       return false;
     }
@@ -595,7 +595,7 @@ bool DiskFile::Write(u64 _offset, const void *buffer, size_t length, LengthType 
 
     if (fseek(file, (OffsetType)_offset, SEEK_SET))
     {
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Could not write " << (u64)length << " bytes to " << filename << " at offset " << _offset << ": " << strerror(errno) << std::endl;
       return false;
     }
@@ -613,7 +613,7 @@ bool DiskFile::Write(u64 _offset, const void *buffer, size_t length, LengthType 
     LengthType wrote = fwrite(buffer, 1, write, file);
     if (wrote != write)
     {
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Could not write " << (u64)length << " bytes to " << filename << " at offset " << _offset << ": " << strerror(errno) << std::endl;
       return false;
     }
@@ -642,7 +642,7 @@ bool DiskFile::Open(const std::string &_filename, u64 _filesize)
 
   if (_filesize > (u64)MaxOffset)
   {
-    #pragma omp critical
+    #pragma omp critical(stdio)
     *serr << "File size for " << _filename << " is too large." << std::endl;
     return false;
   }
@@ -669,7 +669,7 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxleng
   {
     if (_offset > (u64)MaxOffset)
     {
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Could not read " << (u64)length << " bytes from " << filename << " at offset " << _offset << std::endl;
       return false;
     }
@@ -677,7 +677,7 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxleng
 
     if (fseek(file, (OffsetType)_offset, SEEK_SET))
     {
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Could not read " << (u64)length << " bytes from " << filename << " at offset " << _offset << ": " << strerror(errno) << std::endl;
       return false;
     }
@@ -698,7 +698,7 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxleng
     {
       // NOTE: This can happen on error or when hitting the end-of-file.
 
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << "Could not read " << (u64)length << " bytes from " << filename << " at offset " << _offset << ": " << strerror(errno) << std::endl;
       return false;
     }
@@ -979,7 +979,7 @@ bool DiskFile::Delete(void)
 #endif
   else
   {
-    #pragma omp critical
+    #pragma omp critical(stdio)
     *serr << "Cannot delete " << filename << std::endl;
 
     return false;
@@ -1040,7 +1040,7 @@ bool DiskFile::Rename(void)
     // Check path length against maximum
     if (newname.length() > _MAX_PATH)
     {
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << filename << " pathlength is more than " << _MAX_PATH << "." << std::endl;
       return false;
     }
@@ -1067,7 +1067,7 @@ bool DiskFile::Rename(void)
     // Check path length against maximum
     if (newname.length() > _MAX_PATH)
     {
-      #pragma omp critical
+      #pragma omp critical(stdio)
       *serr << filename << " pathlength is more than " << _MAX_PATH << "." << std::endl;
       return false;
     }
@@ -1118,7 +1118,7 @@ bool DiskFile::Rename(std::string _filename)
     return true;
   }
 
-  #pragma omp critical
+  #pragma omp critical(stdio)
   *serr << filename << " cannot be renamed to " << _filename << std::endl;
 
   return false;
@@ -1135,7 +1135,7 @@ bool DiskFile::Rename(std::string _filename)
     return true;
   }
 
-  #pragma omp critical
+  #pragma omp critical(stdio)
   *serr << filename << " cannot be renamed to " << _filename << std::endl;
 
   return false;

--- a/src/libpar2internal.h
+++ b/src/libpar2internal.h
@@ -205,6 +205,7 @@ typedef unsigned int     size_t;
 #include "libpar2.h"
 
 #include "letype.h"
+#include "progressmeter.h"
 
 #include "galois.h"
 #include "crc.h"

--- a/src/par1repairer.cpp
+++ b/src/par1repairer.cpp
@@ -813,9 +813,6 @@ bool Par1Repairer::VerifyDataFile(DiskFile *diskfile, Par1RepairerSourceFile *so
         ProgressMeter<u64> progress(sout, message, filesize);
         while (offset < filesize)
         {
-          if (noiselevel > nlQuiet)
-            progress.Update(offset);
-
           want = (size_t)std::min((u64)buffersize, filesize-offset);
 
           if (!diskfile->Read(offset, buffer, want))
@@ -827,6 +824,9 @@ bool Par1Repairer::VerifyDataFile(DiskFile *diskfile, Par1RepairerSourceFile *so
           contextfull.Update(buffer, want);
 
           offset += want;
+
+          if (noiselevel > nlQuiet)
+            progress.Update(offset);
         }
       }
 

--- a/src/par1repairer.cpp
+++ b/src/par1repairer.cpp
@@ -135,7 +135,7 @@ Result Par1Repairer::Process(const size_t memorylimit,
     return eLogicError;
 
   if (noiselevel > nlQuiet)
-    sout << std::endl << "Verifying source files:" << std::endl << std::endl;
+    sout << "\nVerifying source files:\n" << std::endl;
 
   // Check for the existence of and verify each of the source files
   if (!VerifySourceFiles())
@@ -144,7 +144,7 @@ Result Par1Repairer::Process(const size_t memorylimit,
   if (completefilecount<sourcefiles.size())
   {
     if (noiselevel > nlQuiet)
-      sout << std::endl << "Scanning extra files:" << std::endl << std::endl;
+      sout << "\nScanning extra files:\n" << std::endl;
 
     // Check any other files specified on the command line to see if they are
     // actually copies of the source files that have the wrong filename
@@ -156,7 +156,7 @@ Result Par1Repairer::Process(const size_t memorylimit,
   UpdateVerificationResults();
 
   if (noiselevel > nlSilent)
-    sout << std::endl;
+    sout << '\n';
 
   // Check the verification results and report the details
   if (!CheckVerificationResults())
@@ -169,7 +169,7 @@ Result Par1Repairer::Process(const size_t memorylimit,
     if (dorepair)
     {
       if (noiselevel > nlSilent)
-        sout << std::endl;
+        sout << '\n';
 
       // Rename any damaged or missnamed target files.
       if (!RenameTargetFiles())
@@ -200,7 +200,7 @@ Result Par1Repairer::Process(const size_t memorylimit,
           return eMemoryError;
         }
         if (noiselevel > nlSilent)
-          sout << std::endl;
+          sout << '\n';
 
         // Set the total amount of data to be processed.
         progress = 0;
@@ -226,7 +226,7 @@ Result Par1Repairer::Process(const size_t memorylimit,
         }
 
         if (noiselevel > nlSilent)
-          sout << std::endl << "Verifying repaired files:" << std::endl << std::endl;
+          sout << "\nVerifying repaired files:\n" << std::endl;
 
         // Verify that all of the reconstructed target files are now correct
         if (!VerifyTargetFiles())
@@ -246,7 +246,7 @@ Result Par1Repairer::Process(const size_t memorylimit,
       else
       {
         if (noiselevel > nlSilent)
-          sout << std::endl << "Repair complete." << std::endl;
+          sout << "\nRepair complete." << std::endl;
       }
     }
     else
@@ -1033,8 +1033,8 @@ bool Par1Repairer::CheckVerificationResults(void)
     {
       if (noiselevel > nlSilent)
       {
-        sout << "Repair is not possible." << std::endl;
-        sout << "You need " << damagedfilecount+missingfilecount - recoveryblocks.size()
+        sout << "Repair is not possible.\n"
+             "You need " << damagedfilecount+missingfilecount - recoveryblocks.size()
              << " more recovery files to be able to repair." << std::endl;
       }
 
@@ -1454,7 +1454,7 @@ bool Par1Repairer::RemoveBackupFiles(void)
   if (noiselevel > nlSilent
       && bf != backuplist.end())
   {
-    sout << std::endl << "Purge backup files." << std::endl;
+    sout << "\nPurge backup files." << std::endl;
   }
 
   // Iterate through each file in the backuplist
@@ -1483,7 +1483,7 @@ bool Par1Repairer::RemoveParFiles(void)
   if (noiselevel > nlSilent
       && !parlist.empty())
   {
-      sout << std::endl << "Purge par files." << std::endl;
+      sout << "\nPurge par files." << std::endl;
   }
 
   for (std::list<std::string>::const_iterator s=parlist.begin(); s!=parlist.end(); ++s)

--- a/src/par1repairer.cpp
+++ b/src/par1repairer.cpp
@@ -54,8 +54,6 @@ Par1Repairer::Par1Repairer(std::ostream &sout, std::ostream &serr, const NoiseLe
 , inputblocks()
 , outputblocks()
 , rs()
-, progress(0)
-, totaldata(0)
 , inputbuffersize(0)
 , inputbuffer(0)
 , outputbufferalignment(0)
@@ -203,8 +201,7 @@ Result Par1Repairer::Process(const size_t memorylimit,
           sout << '\n';
 
         // Set the total amount of data to be processed.
-        progress = 0;
-        totaldata = blocksize * sourcefiles.size() * verifylist.size();
+        ProgressMeter<u64> progress(sout, "Repairing: ", blocksize * sourcefiles.size() * verifylist.size());
 
         // Start at an offset of 0 within a block.
         u64 blockoffset = 0;
@@ -214,7 +211,7 @@ Result Par1Repairer::Process(const size_t memorylimit,
           size_t blocklength = (size_t)std::min((u64)chunksize, blocksize-blockoffset);
 
           // Read source data, process it through the RS matrix and write it to disk.
-          if (!ProcessData(blockoffset, blocklength))
+          if (!ProcessData(blockoffset, blocklength, progress))
           {
             // Delete all of the partly reconstructed files
             DeleteIncompleteTargetFiles();
@@ -810,20 +807,14 @@ bool Par1Repairer::VerifyDataFile(DiskFile *diskfile, Par1RepairerSourceFile *so
       // Compute the MD5 hash of the whole file
       if (filesize > 16384)
       {
-        u64 progress = 0;
         u64 offset = 16384;
+        std::string message = "Scanning: \"";
+        message.append(name).append("\": ");
+        ProgressMeter<u64> progress(sout, message, filesize);
         while (offset < filesize)
         {
           if (noiselevel > nlQuiet)
-          {
-            // Update a progress indicator
-            u32 oldfraction = (u32)(1000 * (progress) / filesize);
-            u32 newfraction = (u32)(1000 * (progress=offset) / filesize);
-            if (oldfraction != newfraction)
-            {
-              sout << "Scanning: \"" << name << "\": " << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
-            }
-          }
+            progress.Update(offset);
 
           want = (size_t)std::min((u64)buffersize, filesize-offset);
 
@@ -1297,7 +1288,7 @@ bool Par1Repairer::AllocateBuffers(size_t memorylimit)
 }
 
 // Read source data, process it through the RS matrix and write it to disk.
-bool Par1Repairer::ProcessData(u64 blockoffset, size_t blocklength)
+bool Par1Repairer::ProcessData(u64 blockoffset, size_t blocklength, ProgressMeter<u64> &progress)
 {
   u64 totalwritten = 0;
   // Clear the output buffer
@@ -1326,17 +1317,7 @@ bool Par1Repairer::ProcessData(u64 blockoffset, size_t blocklength)
         rs.Process(blocklength, inputindex, inputbuffer, outputindex, outbuf);
 
         if (noiselevel > nlQuiet)
-        {
-          // Update a progress indicator
-          u32 oldfraction = (u32)(1000 * progress / totaldata);
-          progress += blocklength;
-          u32 newfraction = (u32)(1000 * progress / totaldata);
-
-          if (oldfraction != newfraction)
-          {
-            sout << "Repairing: " << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
-          }
-        }
+          progress.Add(blocklength);
       }
 
       ++inputblock;

--- a/src/par1repairer.h
+++ b/src/par1repairer.h
@@ -82,7 +82,7 @@ protected:
   bool AllocateBuffers(size_t memorylimit);
 
   // Read source data, process it through the RS matrix and write it to disk.
-  bool ProcessData(u64 blockoffset, size_t blocklength);
+  bool ProcessData(u64 blockoffset, size_t blocklength, ProgressMeter<u64> &progress);
 
   // Verify that all of the reconstructed target files are now correct
   bool VerifyTargetFiles(void);
@@ -126,9 +126,6 @@ protected:
   std::vector<DataBlock*>   outputblocks;            // Which DataBlocks have to calculated using RS
 
   ReedSolomon<Galois8>      rs;                      // The Reed Solomon matrix.
-
-  u64                       progress;                // How much data has been processed.
-  u64                       totaldata;               // Total amount of data to be processed.
 
   size_t                    inputbuffersize;
   u8                       *inputbuffer;             // Buffer for reading DataBlocks (chunksize)

--- a/src/par2cmdline.cpp
+++ b/src/par2cmdline.cpp
@@ -63,6 +63,9 @@ int main(int argc, char* argv[])
 		"Error: the assumed sizes of integers is wrong!");
 
 
+  // We only output using C++ iostreams
+  std::ios::sync_with_stdio(false);
+
   // Parse the command line
   CommandLine *commandline = new CommandLine;
 

--- a/src/par2creator.cpp
+++ b/src/par2creator.cpp
@@ -376,7 +376,7 @@ bool Par2Creator::OpenSourceFiles(const std::vector<std::string> &extrafiles, st
 
     if (noiselevel > nlSilent)
     {
-      #pragma omp critical
+      #pragma omp critical(stdio)
       sout << "Opening: " << name << std::endl;
     }
 
@@ -852,7 +852,7 @@ bool Par2Creator::ProcessData(u64 blockoffset, size_t blocklength)
 
         if (oldfraction != newfraction)
         {
-          #pragma omp critical
+          #pragma omp critical(stdio)
           sout << "Processing: " << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
         }
       }

--- a/src/par2creator.cpp
+++ b/src/par2creator.cpp
@@ -152,12 +152,12 @@ Result Par2Creator::Process(
   if (noiselevel > nlQuiet)
   {
     // Display information.
-    sout << "Block size: " << blocksize << std::endl;
-    sout << "Source file count: " << sourcefilecount << std::endl;
-    sout << "Source block count: " << sourceblockcount << std::endl;
-    sout << "Recovery block count: " << recoveryblockcount << std::endl;
-    sout << "Recovery file count: " << recoveryfilecount << std::endl;
-    sout << std::endl;
+    sout << "Block size: " << blocksize << "\n"
+      "Source file count: " << sourcefilecount << "\n"
+      "Source block count: " << sourceblockcount << "\n"
+      "Recovery block count: " << recoveryblockcount << "\n"
+      "Recovery file count: " << recoveryfilecount << "\n"
+      << std::endl;
   }
 
   // Open all of the source files, compute the Hashes and CRC values, and store

--- a/src/par2creator.cpp
+++ b/src/par2creator.cpp
@@ -63,13 +63,8 @@ Par2Creator::Par2Creator(std::ostream &sout, std::ostream &serr, const NoiseLeve
 , criticalpackets()
 , criticalpacketentries()
 , rs()
-, progress(0)
-, totaldata(0)
 
 , deferhashcomputation(false)
-#ifdef _OPENMP
-, mttotalsize(0)
-#endif
 {
 }
 
@@ -192,8 +187,7 @@ Result Par2Creator::Process(
       return eLogicError;
 
     // Set the total amount of data to be processed.
-    progress = 0;
-    totaldata = blocksize * sourceblockcount * recoveryblockcount;
+    ProgressMeter<u64> progress(sout, "Processing: ", blocksize * sourceblockcount * recoveryblockcount);
 
     // Start at an offset of 0 within a block.
     u64 blockoffset = 0;
@@ -203,7 +197,7 @@ Result Par2Creator::Process(
       size_t blocklength = (size_t)std::min((u64)chunksize, blocksize-blockoffset);
 
       // Read source data, process it through the RS matrix and write it to disk.
-      if (!ProcessData(blockoffset, blocklength))
+      if (!ProcessData(blockoffset, blocklength, progress))
         return eFileIOError;
 
       blockoffset += blocklength;
@@ -354,11 +348,13 @@ bool Par2Creator::OpenSourceFiles(const std::vector<std::string> &extrafiles, st
 {
 #ifdef _OPENMP
   bool openfailed = false;
-  u64 totalprogress = 0;
 
   //Total size of files for mt-progress line
+  u64 mttotalsize = 0;
   for (size_t i=0; i<extrafiles.size(); ++i)
     mttotalsize += DiskFile::GetFileSize(extrafiles[i]);
+
+  ProgressMeter<u64> progress(sout, "", mttotalsize);
 #endif
 
   #pragma omp parallel for schedule(dynamic) num_threads(Par2Creator::GetFileThreads())
@@ -382,7 +378,7 @@ bool Par2Creator::OpenSourceFiles(const std::vector<std::string> &extrafiles, st
 
     // Open the source file and compute its Hashes and CRCs.
 #ifdef _OPENMP
-    if (!sourcefile->Open(noiselevel, sout, serr, extrafiles[i], blocksize, deferhashcomputation, basepath, mttotalsize, totalprogress))
+    if (!sourcefile->Open(noiselevel, sout, serr, extrafiles[i], blocksize, deferhashcomputation, basepath, progress))
 #else
     if (!sourcefile->Open(noiselevel, sout, serr, extrafiles[i], blocksize, deferhashcomputation, basepath))
 #endif
@@ -780,7 +776,7 @@ bool Par2Creator::ComputeRSMatrix(void)
 }
 
 // Read source data, process it through the RS matrix and write it to disk.
-bool Par2Creator::ProcessData(u64 blockoffset, size_t blocklength)
+bool Par2Creator::ProcessData(u64 blockoffset, size_t blocklength, ProgressMeter<u64> &progress)
 {
   // Clear the output buffer
   memset(outputbuffer, 0, chunksize * recoveryblockcount);
@@ -843,19 +839,7 @@ bool Par2Creator::ProcessData(u64 blockoffset, size_t blocklength)
       rs.Process(blocklength, inputblock, inputbuffer, internalOutputblock, outbuf);
 
       if (noiselevel > nlQuiet)
-      {
-        // Update a progress indicator
-        u32 oldfraction = (u32)(1000 * progress / totaldata);
-        #pragma omp atomic
-        progress += blocklength;
-        u32 newfraction = (u32)(1000 * progress / totaldata);
-
-        if (oldfraction != newfraction)
-        {
-          #pragma omp critical(stdio)
-          sout << "Processing: " << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
-        }
-      }
+        progress.Add(blocklength);
     }
 
     // Work out which source file the next block belongs to

--- a/src/par2creator.h
+++ b/src/par2creator.h
@@ -84,7 +84,7 @@ protected:
   bool ComputeRSMatrix(void);
 
   // Read source data, process it through the RS matrix and write it to disk.
-  bool ProcessData(u64 blockoffset, size_t blocklength);
+  bool ProcessData(u64 blockoffset, size_t blocklength, ProgressMeter<u64> &progress);
 
   // Finish computation of the recovery packets and write the headers to disk.
   bool WriteRecoveryPacketHeaders(void);
@@ -155,16 +155,10 @@ protected:
 
   ReedSolomon<Galois16> rs;   // The Reed Solomon matrix.
 
-  u64 progress;     // How much data has been processed.
-  u64 totaldata;    // Total amount of data to be processed.
-
   bool deferhashcomputation; // If we have enough memory to compute all recovery data
                              // in one pass, then we can defer the computation of
                              // the full file hash and block crc and hashes until
                              // the recovery data is computed.
-#ifdef _OPENMP
-  u64 mttotalsize;           // Total size of files for mt-progress line
-#endif
 };
 
 #endif // __PAR2CREATOR_H__

--- a/src/par2creatorsourcefile.cpp
+++ b/src/par2creatorsourcefile.cpp
@@ -53,7 +53,7 @@ Par2CreatorSourceFile::~Par2CreatorSourceFile(void)
 // in a file description packet and a file verification packet.
 
 #ifdef _OPENMP
-bool Par2CreatorSourceFile::Open(NoiseLevel noiselevel, std::ostream &sout, std::ostream &serr, const std::string &extrafile, u64 blocksize, bool deferhashcomputation, std::string basepath, u64 totalsize, u64 &totalprogress)
+bool Par2CreatorSourceFile::Open(NoiseLevel noiselevel, std::ostream &sout, std::ostream &serr, const std::string &extrafile, u64 blocksize, bool deferhashcomputation, std::string basepath, ProgressMeter<u64> &progress)
 #else
 bool Par2CreatorSourceFile::Open(NoiseLevel noiselevel, std::ostream &sout, std::ostream &serr, const std::string &extrafile, u64 blocksize, bool deferhashcomputation, std::string basepath)
 #endif
@@ -138,6 +138,9 @@ bool Par2CreatorSourceFile::Open(NoiseLevel noiselevel, std::ostream &sout, std:
     MD5Context filecontext;
     MD5Context blockcontext;
     u32        blockcrc = 0;
+#ifndef _OPENMP
+    ProgressMeter<u64> progress(sout, "", filesize);
+#endif
 
     // Whilst we have not reached the end of the file
     while (offset < filesize)
@@ -213,24 +216,7 @@ bool Par2CreatorSourceFile::Open(NoiseLevel noiselevel, std::ostream &sout, std:
       }
 
       if (noiselevel > nlQuiet)
-      {
-        // Display progress
-#ifdef _OPENMP
-        u32 oldfraction = (u32)(1000 * totalprogress / totalsize);
-        #pragma omp atomic
-        totalprogress += want;
-        u32 newfraction = (u32)(1000 * totalprogress / totalsize);
-#else
-        u32 oldfraction = (u32)(1000 * offset / filesize);
-        u32 newfraction = (u32)(1000 * (offset + want) / filesize);
-#endif
-
-        if (oldfraction != newfraction)
-        {
-          #pragma omp critical(stdio)
-          sout << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
-        }
-      }
+        progress.Add(want);
 
       offset += want;
     }

--- a/src/par2creatorsourcefile.cpp
+++ b/src/par2creatorsourcefile.cpp
@@ -227,7 +227,7 @@ bool Par2CreatorSourceFile::Open(NoiseLevel noiselevel, std::ostream &sout, std:
 
         if (oldfraction != newfraction)
         {
-          #pragma omp critical
+          #pragma omp critical(stdio)
           sout << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
         }
       }

--- a/src/par2creatorsourcefile.h
+++ b/src/par2creatorsourcefile.h
@@ -41,7 +41,7 @@ public:
 
   // Open the source file and compute the Hashes and CRCs.
 #ifdef _OPENMP
-  bool Open(NoiseLevel noiselevel, std::ostream &sout, std::ostream &serr, const std::string &extrafile, u64 blocksize, bool deferhashcomputation, std::string basepath, u64 totalsize, u64 &totalprogress);
+  bool Open(NoiseLevel noiselevel, std::ostream &sout, std::ostream &serr, const std::string &extrafile, u64 blocksize, bool deferhashcomputation, std::string basepath, ProgressMeter<u64> &progress);
 #else
   bool Open(NoiseLevel noiselevel, std::ostream &sout, std::ostream &serr, const std::string &extrafile, u64 blocksize, bool deferhashcomputation, std::string basepath);
 #endif

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -1671,11 +1671,9 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
     {
       if (lastmatchoffset < filechecksummer.Offset() && noiselevel > nlNormal)
       {
-        progress.ClearLine();
-        #pragma omp critical(stdio)
-        sout << "No data found between offset " << lastmatchoffset
-          << " and " << filechecksummer.Offset() << '\n';
-        progress.Print();
+        progress.PrintLine((std::ostringstream()
+          << "No data found between offset " << lastmatchoffset
+          << " and " << filechecksummer.Offset()).str());
       }
 
       // Is this the first match
@@ -1797,11 +1795,9 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
 
   if (lastmatchoffset < filechecksummer.Offset() && noiselevel > nlNormal)
   {
-    progress.ClearLine();
-    #pragma omp critical(stdio)
-    sout << "No data found between offset " << lastmatchoffset
-      << " and " << filechecksummer.Offset() << std::endl;
-    progress.Print();
+    progress.PrintLine((std::ostringstream()
+      << "No data found between offset " << lastmatchoffset
+      << " and " << filechecksummer.Offset()).str());
   }
 
 #ifdef _OPENMP
@@ -1817,14 +1813,12 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
 
   if (noiselevel >= nlDebug)
   {
-    progress.ClearLine();
-    #pragma omp critical(stdio)
-    {
+    std::ostringstream ss;
     if (duplicatecount > 0)
-      sout << "[DEBUG] duplicates: " << duplicatecount << '\n';
-    sout << "[DEBUG] matchcount: " << count << "\n"
-      "[DEBUG] ----------------------" << std::endl;
-    }
+      ss << "[DEBUG] duplicates: " << duplicatecount << '\n';
+    ss << "[DEBUG] matchcount: " << count << "\n"
+      "[DEBUG] ----------------------";
+    progress.PrintLine(ss.str());
   }
 
   // Did we make any matches at all

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -1233,18 +1233,16 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
 
     if (noiselevel >= nlDebug)
     {
-      #pragma omp critical
-      {
+      #pragma omp critical(stdio)
       sout << "[DEBUG] VerifySourceFiles ----\n"
         "[DEBUG] file: " << file << "\n"
         "[DEBUG] name: " << name << "\n"
         "[DEBUG] targ: " << target_pathname << std::endl;
-      }
     }
 
     // if the target file is in the list of extra files, we remove it
     // from the extra files.
-    #pragma omp critical
+    #pragma omp critical(extrafiles)
     {
       std::vector<std::string>::iterator it = extrafiles.begin();
       for (; it != extrafiles.end(); ++it)
@@ -1261,12 +1259,12 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
 
     // Check to see if we have already used this file
     bool b;
-    #pragma omp critical
+    #pragma omp critical(diskFileMap)
     b = diskFileMap.Find(file) != 0;
     if (b)
     {
       // The file has already been used!
-      #pragma omp critical
+      #pragma omp critical(stdio)
       serr << "Source file " << name << " is a duplicate." << std::endl;
 
       finalresult = false;
@@ -1286,7 +1284,7 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
 
         // Remember that we have processed this file
         bool success;
-        #pragma omp critical
+        #pragma omp critical(diskFileMap)
         success = diskFileMap.Insert(diskfile);
         assert(success);
         // Do the actual verification
@@ -1303,7 +1301,7 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
 
         if (noiselevel > nlSilent)
         {
-          #pragma omp critical
+          #pragma omp critical(stdio)
           sout << "Target: \"" << name << "\" - missing." << std::endl;
         }
       }
@@ -1347,7 +1345,7 @@ bool Par2Repairer::VerifyExtraFiles(const std::vector<std::string> &extrafiles, 
 
         // Has this file already been dealt with
         bool b;
-        #pragma omp critical
+        #pragma omp critical(diskFileMap)
         b = diskFileMap.Find(filename) == 0;
         if (b)
         {
@@ -1362,7 +1360,7 @@ bool Par2Repairer::VerifyExtraFiles(const std::vector<std::string> &extrafiles, 
 
           // Remember that we have processed this file
           bool success;
-          #pragma omp critical
+          #pragma omp critical(diskFileMap)
           success = diskFileMap.Insert(diskfile);
           assert(success);
 
@@ -1520,7 +1518,7 @@ bool Par2Repairer::VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *so
       {
         if (noiselevel > nlSilent)
         {
-          #pragma omp critical
+          #pragma omp critical(stdio)
           sout << diskfile->FileName() << " is a perfect match for " << sourcefile->GetDescriptionPacket()->FileName() << std::endl;
         }
         // Record that we have a perfect match for this source file
@@ -1588,7 +1586,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
     // If the file is empty, then just return
     if (noiselevel > nlSilent)
     {
-      #pragma omp critical
+      #pragma omp critical(stdio)
       sout << "File: \"" << name << "\" - empty." << std::endl;
     }
     return true;
@@ -1648,7 +1646,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
 #ifdef _OPENMP
   if (noiselevel > nlQuiet)
   {
-    #pragma omp critical
+    #pragma omp critical(stdio)
     sout << "Opening: \"" << shortname << "\"" << std::endl;
   }
 #endif
@@ -1684,7 +1682,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
 
         if (oldfraction != newfraction)
         {
-          #pragma omp critical
+          #pragma omp critical(stdio)
           sout << "Scanning: " << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
 
           progressline = true;
@@ -1730,11 +1728,11 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
       {
         if (progressline)
         {
-          #pragma omp critical
+          #pragma omp critical(stdio)
           sout << '\n';
           progressline = false;
         }
-        #pragma omp critical
+        #pragma omp critical(stdio)
         sout << "No data found between offset " << lastmatchoffset
           << " and " << filechecksummer.Offset() << std::endl;
       }
@@ -1870,11 +1868,11 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
   {
     if (progressline)
     {
-      #pragma omp critical
+      #pragma omp critical(stdio)
       sout << '\n';
     }
 
-    #pragma omp critical
+    #pragma omp critical(stdio)
     sout << "No data found between offset " << lastmatchoffset
       << " and " << filechecksummer.Offset() << std::endl;
   }
@@ -1884,7 +1882,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
 
   if (noiselevel >= nlDebug)
   {
-    #pragma omp critical
+    #pragma omp critical(stdio)
     {
     // Clear out old scanning line
     sout << std::setw(shortname.size()+19) << std::setfill(' ') << "";
@@ -1917,7 +1915,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
           // Were we scanning the target file or an extra file
           if (originalsourcefile != 0)
           {
-            #pragma omp critical
+            #pragma omp critical(stdio)
             sout << "Target: \""
               << name
               << "\" - damaged, found "
@@ -1927,7 +1925,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
           }
           else
           {
-            #pragma omp critical
+            #pragma omp critical(stdio)
             sout << "File: \""
               << name
               << "\" - found "
@@ -1941,7 +1939,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
           // Did we find data blocks that belong to the target file
           if (originalsourcefile == sourcefile)
           {
-            #pragma omp critical
+            #pragma omp critical(stdio)
             sout << "Target: \""
               << name
               << "\" - damaged. Found "
@@ -1957,7 +1955,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
             std::string targetname;
             DiskFile::SplitRelativeFilename(sourcefile->TargetFileName(), basepath, targetname);
 
-            #pragma omp critical
+            #pragma omp critical(stdio)
             sout << "Target: \""
               << name
               << "\" - damaged. Found "
@@ -1974,7 +1972,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
             std::string targetname;
             DiskFile::SplitRelativeFilename(sourcefile->TargetFileName(), basepath, targetname);
 
-            #pragma omp critical
+            #pragma omp critical(stdio)
             sout << "File: \""
               << name
               << "\" - found "
@@ -1990,7 +1988,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
 
         if (skippeddata > 0)
         {
-          #pragma omp critical
+          #pragma omp critical(stdio)
           sout << skippeddata << " bytes of data were skipped whilst scanning.\n"
             "If there are not enough blocks found to repair: try again "
             "with the -N option." << std::endl;
@@ -2004,7 +2002,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
         // Did we match the target file
         if (originalsourcefile == sourcefile)
         {
-          #pragma omp critical
+          #pragma omp critical(stdio)
           sout << "Target: \"" << name << "\" - found." << std::endl;
         }
         // Were we scanning the target file or an extra file
@@ -2013,7 +2011,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
           std::string targetname;
           DiskFile::SplitRelativeFilename(sourcefile->TargetFileName(), basepath, targetname);
 
-          #pragma omp critical
+          #pragma omp critical(stdio)
           sout << "Target: \""
             << name
             << "\" - is a match for \""
@@ -2026,7 +2024,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
           std::string targetname;
           DiskFile::SplitRelativeFilename(sourcefile->TargetFileName(), basepath, targetname);
 
-          #pragma omp critical
+          #pragma omp critical(stdio)
           sout << "File: \""
             << name
             << "\" - is a match for \""
@@ -2047,7 +2045,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
       // had already found in other files.
       if (duplicatecount > 0)
       {
-        #pragma omp critical
+        #pragma omp critical(stdio)
         sout << "File: \""
           << name
           << "\" - found "
@@ -2057,7 +2055,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
       }
       else
       {
-        #pragma omp critical
+        #pragma omp critical(stdio)
         sout << "File: \""
           << name
           << "\" - no data found."
@@ -2066,7 +2064,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
 
       if (skippeddata > 0)
       {
-        #pragma omp critical
+        #pragma omp critical(stdio)
         sout << skippeddata << " bytes of data were skipped whilst scanning.\n"
           "If there are not enough blocks found to repair: try again "
           "with the -N option." << std::endl;
@@ -2566,7 +2564,7 @@ bool Par2Repairer::ProcessData(u64 blockoffset, size_t blocklength)
 
           if (oldfraction != newfraction)
           {
-            #pragma omp critical
+            #pragma omp critical(stdio)
             sout << "Repairing: " << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
           }
         }

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -1795,20 +1795,20 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
     }
   }
 
+#ifdef _OPENMP
+  if (noiselevel > nlQuiet)
+  {
+    if (filechecksummer.Offset() == diskfile->FileSize())
+      progress.Add(filechecksummer.Offset() - oldoffset);
+  }
+#endif
+
   if (lastmatchoffset < filechecksummer.Offset() && noiselevel > nlNormal)
   {
     progress.PrintLine((std::ostringstream()
       << "No data found between offset " << lastmatchoffset
       << " and " << filechecksummer.Offset()).str());
   }
-
-#ifdef _OPENMP
-  if (noiselevel > nlQuiet)
-  {
-    if (filechecksummer.Offset() == diskfile->FileSize())
-      progress.AddSilent(filechecksummer.Offset() - oldoffset);
-  }
-#endif
 
   // Get the Full and 16k hash values of the file
   filechecksummer.GetFileHashes(hashfull, hash16k);

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -527,6 +527,8 @@ bool Par2Repairer::LoadPacketsFromFile(std::string filename)
       // Advance to the next packet
       offset += header.length;
     }
+    if (noiselevel > nlQuiet)
+      progress.Update(offset);
 
     delete [] buffer;
   }

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -177,7 +177,7 @@ Result Par2Repairer::Process(
     return eLogicError;
 
   if (noiselevel > nlQuiet)
-    sout << std::endl;
+    sout << '\n';
 
   // Check that the packets are consistent and discard any that are not
   if (!CheckPacketConsistency())
@@ -218,7 +218,7 @@ Result Par2Repairer::Process(
   UpdateVerificationResults();
 
   if (noiselevel > nlSilent)
-    sout << std::endl;
+    sout << '\n';
 
   // Check the verification results and report the results
   if (!CheckVerificationResults())
@@ -231,7 +231,7 @@ Result Par2Repairer::Process(
     if (dorepair)
     {
       if (noiselevel > nlSilent)
-        sout << std::endl;
+        sout << '\n';
 
       // Rename any damaged or missnamed target files.
       if (!RenameTargetFiles())
@@ -256,7 +256,7 @@ Result Par2Repairer::Process(
         }
 
         if (noiselevel > nlSilent)
-          sout << std::endl;
+          sout << '\n';
 
         // Allocate memory buffers for reading and writing data to disk.
         if (!AllocateBuffers(memorylimit))
@@ -290,7 +290,7 @@ Result Par2Repairer::Process(
         }
 
         if (noiselevel > nlSilent)
-          sout << std::endl << "Verifying repaired files:" << std::endl << std::endl;
+          sout << "\nVerifying repaired files:\n" << std::endl;
 
         // Verify that all of the reconstructed target files are now correct
         if (!VerifyTargetFiles(basepath))
@@ -310,7 +310,7 @@ Result Par2Repairer::Process(
       else
       {
         if (noiselevel > nlSilent)
-          sout << std::endl << "Repair complete." << std::endl;
+          sout << "\nRepair complete." << std::endl;
       }
     }
     else
@@ -966,10 +966,8 @@ bool Par2Repairer::CheckPacketConsistency(void)
       << mainpacket->RecoverableFileCount()
       << " recoverable files and "
       << mainpacket->TotalFileCount() - mainpacket->RecoverableFileCount()
-      << " other files."
-      << std::endl;
-
-    sout << "The block size used was "
+      << " other files.\n"
+         "The block size used was "
       << blocksize
       << " bytes."
       << std::endl;
@@ -1093,10 +1091,8 @@ bool Par2Repairer::AllocateSourceBlocks(void)
     {
       sout << "There are a total of "
         << sourceblockcount
-        << " data blocks."
-        << std::endl;
-
-      sout << "The total size of the data files is "
+        << " data blocks.\n"
+           "The total size of the data files is "
         << totalsize
         << " bytes."
         << std::endl;
@@ -1174,7 +1170,7 @@ static bool SortSourceFilesByFileName(Par2RepairerSourceFile *low,
 bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<std::string>& extrafiles)
 {
   if (noiselevel > nlQuiet)
-    sout << std::endl << "Verifying source files:" << std::endl << std::endl;
+    sout << "\nVerifying source files:\n" << std::endl;
 
   bool finalresult = true;
 
@@ -1207,7 +1203,7 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
       // Was this one of the recoverable files
       if (filenumber < mainpacket->RecoverableFileCount())
       {
-        serr << "No details available for recoverable file number " << filenumber+1 << "." << std::endl << "Recovery will not be possible." << std::endl;
+        serr << "No details available for recoverable file number " << filenumber+1 << ".\nRecovery will not be possible." << std::endl;
 
         // Set error but let verification of other files continue
         finalresult = false;
@@ -1239,10 +1235,10 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
     {
       #pragma omp critical
       {
-      sout << "[DEBUG] VerifySourceFiles ----" << std::endl;
-      sout << "[DEBUG] file: " << file << std::endl;
-      sout << "[DEBUG] name: " << name << std::endl;
-      sout << "[DEBUG] targ: " << target_pathname << std::endl;
+      sout << "[DEBUG] VerifySourceFiles ----\n"
+        "[DEBUG] file: " << file << "\n"
+        "[DEBUG] name: " << name << "\n"
+        "[DEBUG] targ: " << target_pathname << std::endl;
       }
     }
 
@@ -1324,7 +1320,7 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
 bool Par2Repairer::VerifyExtraFiles(const std::vector<std::string> &extrafiles, const std::string &basepath, const bool renameonly)
 {
   if (noiselevel > nlQuiet)
-    sout << std::endl << "Scanning extra files:" << std::endl << std::endl;
+    sout << "\nScanning extra files:\n" << std::endl;
 
   if (completefilecount < mainpacket->RecoverableFileCount())
   {
@@ -1735,7 +1731,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
         if (progressline)
         {
           #pragma omp critical
-          sout << std::endl;
+          sout << '\n';
           progressline = false;
         }
         #pragma omp critical
@@ -1875,7 +1871,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
     if (progressline)
     {
       #pragma omp critical
-      sout << std::endl;
+      sout << '\n';
     }
 
     #pragma omp critical
@@ -1894,9 +1890,9 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
     sout << std::setw(shortname.size()+19) << std::setfill(' ') << "";
 
     if (duplicatecount > 0)
-      sout << "\r[DEBUG] duplicates: " << duplicatecount << std::endl;
-    sout << "\r[DEBUG] matchcount: " << count << std::endl;
-    sout << "[DEBUG] ----------------------" << std::endl;
+      sout << "\r[DEBUG] duplicates: " << duplicatecount << '\n';
+    sout << "\r[DEBUG] matchcount: " << count << "\n"
+      "[DEBUG] ----------------------" << std::endl;
     }
   }
 
@@ -1995,9 +1991,9 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
         if (skippeddata > 0)
         {
           #pragma omp critical
-          sout << skippeddata << " bytes of data were skipped whilst scanning." << std::endl
-            << "If there are not enough blocks found to repair: try again "
-            << "with the -N option." << std::endl;
+          sout << skippeddata << " bytes of data were skipped whilst scanning.\n"
+            "If there are not enough blocks found to repair: try again "
+            "with the -N option." << std::endl;
         }
       }
     }
@@ -2071,9 +2067,9 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
       if (skippeddata > 0)
       {
         #pragma omp critical
-        sout << skippeddata << " bytes of data were skipped whilst scanning." << std::endl
-          << "If there are not enough blocks found to repair: try again "
-          << "with the -N option." << std::endl;
+        sout << skippeddata << " bytes of data were skipped whilst scanning.\n"
+          "If there are not enough blocks found to repair: try again "
+          "with the -N option." << std::endl;
       }
     }
   }
@@ -2165,10 +2161,10 @@ bool Par2Repairer::CheckVerificationResults(void)
       sout << "Repair is required." << std::endl;
     if (noiselevel > nlQuiet)
     {
-      if (renamedfilecount > 0) sout << renamedfilecount << " file(s) have the wrong name." << std::endl;
-      if (missingfilecount > 0) sout << missingfilecount << " file(s) are missing." << std::endl;
-      if (damagedfilecount > 0) sout << damagedfilecount << " file(s) exist but are damaged." << std::endl;
-      if (completefilecount > 0) sout << completefilecount << " file(s) are ok." << std::endl;
+      if (renamedfilecount > 0) sout << renamedfilecount << " file(s) have the wrong name.\n";
+      if (missingfilecount > 0) sout << missingfilecount << " file(s) are missing.\n";
+      if (damagedfilecount > 0) sout << damagedfilecount << " file(s) exist but are damaged.\n";
+      if (completefilecount > 0) sout << completefilecount << " file(s) are ok.\n";
 
       sout << "You have " << availableblockcount
         << " out of " << sourceblockcount
@@ -2204,8 +2200,8 @@ bool Par2Repairer::CheckVerificationResults(void)
     {
       if (noiselevel > nlSilent)
       {
-        sout << "Repair is not possible." << std::endl;
-        sout << "You need " << missingblockcount - recoverypacketmap.size()
+        sout << "Repair is not possible.\n"
+          "You need " << missingblockcount - recoverypacketmap.size()
           << " more recovery blocks to be able to repair." << std::endl;
       }
 
@@ -2768,7 +2764,7 @@ bool Par2Repairer::RemoveBackupFiles(void)
   if (noiselevel > nlSilent
       && bf != backuplist.end())
   {
-    sout << std::endl << "Purge backup files." << std::endl;
+    sout << "\nPurge backup files." << std::endl;
   }
 
   // Iterate through each file in the backuplist
@@ -2797,7 +2793,7 @@ bool Par2Repairer::RemoveParFiles(void)
   if (noiselevel > nlSilent
       && !par2list.empty())
   {
-    sout << std::endl << "Purge par files." << std::endl;
+    sout << "\nPurge par files." << std::endl;
   }
 
   for (std::list<std::string>::const_iterator s=par2list.begin(); s!=par2list.end(); ++s)

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -28,6 +28,12 @@ static char THIS_FILE[]=__FILE__;
 #endif
 #endif
 
+#ifdef _OPENMP
+#define MT_PROGRESS , progress
+#else
+#define MT_PROGRESS
+#endif
+
 
 // static variable
 #ifdef _OPENMP
@@ -84,16 +90,6 @@ Par2Repairer::Par2Repairer(std::ostream &sout, std::ostream &serr, const NoiseLe
 
   inputbuffer = 0;
   outputbuffer = 0;
-
-  progress = 0;
-  totaldata = 0;
-
-#ifdef _OPENMP
-  mttotalsize = 0;
-  mttotalextrasize = 0;
-  mttotalprogress = 0;
-  mtprocessingextrafiles = false;
-#endif
 }
 
 Par2Repairer::~Par2Repairer(void)
@@ -267,8 +263,7 @@ Result Par2Repairer::Process(
         }
 
         // Set the total amount of data to be processed.
-        progress = 0;
-        totaldata = blocksize * sourceblockcount * (missingblockcount > 0 ? missingblockcount : 1);
+        ProgressMeter<u64> progress(sout, missingblockcount > 0 ? "Repairing: " : "Processing: ", blocksize * sourceblockcount * (missingblockcount > 0 ? missingblockcount : 1));
 
         // Start at an offset of 0 within a block.
         u64 blockoffset = 0;
@@ -278,7 +273,7 @@ Result Par2Repairer::Process(
           size_t blocklength = (size_t)std::min((u64)chunksize, blocksize-blockoffset);
 
           // Read source data, process it through the RS matrix and write it to disk.
-          if (!ProcessData(blockoffset, blocklength))
+          if (!ProcessData(blockoffset, blocklength, progress))
           {
             // Delete all of the partly reconstructed files
             DeleteIncompleteTargetFiles();
@@ -374,7 +369,7 @@ bool Par2Repairer::LoadPacketsFromFile(std::string filename)
     u8 *buffer = new u8[buffersize];
 
     // Progress indicator
-    u64 progress = 0;
+    ProgressMeter<u64> progress(sout, "Loading: ", filesize);
 
     // Start at the beginning of the file
     u64 offset = 0;
@@ -383,16 +378,7 @@ bool Par2Repairer::LoadPacketsFromFile(std::string filename)
     while (offset + sizeof(PACKET_HEADER) <= filesize)
     {
       if (noiselevel > nlQuiet)
-      {
-        // Update a progress indicator
-        u32 oldfraction = (u32)(1000 * progress / filesize);
-        u32 newfraction = (u32)(1000 * offset / filesize);
-        if (oldfraction != newfraction)
-        {
-          sout << "Loading: " << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
-          progress = offset;
-        }
-      }
+        progress.Update(offset);
 
       // Attempt to read the next packet header
       PACKET_HEADER header;
@@ -1182,8 +1168,7 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
   std::vector<Par2RepairerSourceFile*>::iterator sf = sourcefiles.begin();
 
 #ifdef _OPENMP
-  mttotalsize = 0;
-  mttotalprogress = 0;
+  u64 mttotalsize = 0;
 #endif
 
   while (sf != sourcefiles.end())
@@ -1218,6 +1203,9 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
   }
 
   std::sort(sortedfiles.begin(), sortedfiles.end(), SortSourceFilesByFileName);
+#ifdef _OPENMP
+  ProgressMeter<u64> progress(sout, "Scanning: ", mttotalsize);
+#endif
 
   // Start verifying the files
   #pragma omp parallel for schedule(dynamic) num_threads(Par2Repairer::GetFileThreads())
@@ -1288,7 +1276,7 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
         success = diskFileMap.Insert(diskfile);
         assert(success);
         // Do the actual verification
-        if (!VerifyDataFile(diskfile, sourcefile, basepath))
+        if (!VerifyDataFile(diskfile, sourcefile, basepath MT_PROGRESS))
           finalresult = false;
 
         // We have finished with the file for now
@@ -1324,12 +1312,11 @@ bool Par2Repairer::VerifyExtraFiles(const std::vector<std::string> &extrafiles, 
   {
 #ifdef _OPENMP
     // Total size of extra files for mt-progress line
-    mtprocessingextrafiles = true;
-    mttotalprogress = 0;
-    mttotalextrasize = 0;
-
+    u64 mttotalextrasize = 0;
     for (size_t i=0; i<extrafiles.size(); ++i)
       mttotalextrasize += DiskFile::GetFileSize(extrafiles[i]);
+
+    ProgressMeter<u64> progress(sout, "Scanning: ", mttotalextrasize);
 #endif
 
     #pragma omp parallel for schedule(dynamic) num_threads(Par2Repairer::GetFileThreads())
@@ -1365,7 +1352,7 @@ bool Par2Repairer::VerifyExtraFiles(const std::vector<std::string> &extrafiles, 
           assert(success);
 
           // Do the actual verification
-          VerifyDataFile(diskfile, 0, basepath, renameonly);
+          VerifyDataFile(diskfile, 0, basepath MT_PROGRESS, renameonly);
           // Ignore errors
 
           // We have finished with the file for now
@@ -1377,15 +1364,15 @@ bool Par2Repairer::VerifyExtraFiles(const std::vector<std::string> &extrafiles, 
   // Find out how much data we have found
   UpdateVerificationResults();
 
-#if _OPENMP
-    mtprocessingextrafiles = false;
-#endif
-
   return true;
 }
 
 // Attempt to match the data in the DiskFile with the source file
+#ifdef _OPENMP
+bool Par2Repairer::VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const std::string &basepath, ProgressMeter<u64> &progress, const bool renameonly)
+#else
 bool Par2Repairer::VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const std::string &basepath, const bool renameonly)
+#endif
 {
   MatchType matchtype; // What type of match was made
   MD5Hash hashfull;    // The MD5 Hash of the whole file
@@ -1399,7 +1386,8 @@ bool Par2Repairer::VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *so
     // Scan the file at the block level.
 
     if (!ScanDataFile(diskfile,   // [in]      The file to scan
-                      basepath,
+                      basepath
+                      MT_PROGRESS,
                       renameonly, // [in]      Only look for perfect matches
                       sourcefile, // [in/out]  Modified in the match is for another source file
                       matchtype,  // [out]
@@ -1562,7 +1550,10 @@ bool Par2Repairer::VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *so
 // the one specified by the "sourcefile" parameter. If the first data block
 // found is for a different source file then "sourcefile" is changed accordingly.
 bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
-                                std::string                  basepath,     // [in]
+                                std::string             basepath,     // [in]
+#ifdef _OPENMP
+                                ProgressMeter<u64>      &progress,    // [in]
+#endif
                                 const bool              renameonly,   // [in]
                                 Par2RepairerSourceFile* &sourcefile,  // [in/out]
                                 MatchType               &matchtype,   // [out]
@@ -1638,8 +1629,6 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
   // Offset of last data that was found
   u64 lastmatchoffset = 0;
 
-  bool progressline = false;
-
   u64 oldoffset = 0;
   u64 printprogress = 0;
 
@@ -1649,70 +1638,26 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
     #pragma omp critical(stdio)
     sout << "Opening: \"" << shortname << "\"" << std::endl;
   }
+#else
+  std::string message = "Scanning: \"";
+  message.append(shortname).append("\": ");
+  ProgressMeter<u64> progress(sout, message, diskfile->FileSize());
 #endif
 
   // Whilst we have not reached the end of the file
   while (filechecksummer.Offset() < diskfile->FileSize())
   {
-// OPENMP progress line printing
-#ifdef _OPENMP
-    if (noiselevel > nlQuiet)
-    {
-      // Are we processing extrafiles? Use correct total size
-      u64 ts = mtprocessingextrafiles ? mttotalextrasize : mttotalsize;
-
-      // Update progress indicator
-      printprogress += filechecksummer.Offset() - oldoffset;
-      if (printprogress == blocksize || filechecksummer.ShortBlock())
-      {
-        u64 totalprogress;
-#if _OPENMP < 200800
-        totalprogress = mttotalprogress;
-        #pragma omp atomic
-        mttotalprogress += printprogress;
-        totalprogress += printprogress;
-#else
-        #pragma omp atomic capture
-        totalprogress = mttotalprogress += printprogress;
-#endif
-        u32 oldfraction = (u32)(1000 * (totalprogress - printprogress) / ts);
-        u32 newfraction = (u32)(1000 * totalprogress / ts);
-
-        printprogress = 0;
-
-        if (oldfraction != newfraction)
-        {
-          #pragma omp critical(stdio)
-          sout << "Scanning: " << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
-
-          progressline = true;
-        }
-      }
-      oldoffset = filechecksummer.Offset();
-
-    }
-// NON-OPENMP progress line printing
-#else
     if (noiselevel > nlQuiet)
     {
       // Update progress indicator
       printprogress += filechecksummer.Offset() - oldoffset;
       if (printprogress == blocksize || filechecksummer.ShortBlock())
       {
-        u32 oldfraction = (u32)(1000 * (filechecksummer.Offset() - printprogress) / diskfile->FileSize());
-        u32 newfraction = (u32)(1000 * filechecksummer.Offset() / diskfile->FileSize());
+        progress.Add(printprogress);
         printprogress = 0;
-
-        if (oldfraction != newfraction)
-        {
-          sout << "Scanning: \"" << shortname << "\": " << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
-
-          progressline = true;
-        }
       }
       oldoffset = filechecksummer.Offset();
     }
-#endif
 
     // If we fail to find a match, it might be because it was a duplicate of a block
     // that we have already found.
@@ -1726,15 +1671,11 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
     {
       if (lastmatchoffset < filechecksummer.Offset() && noiselevel > nlNormal)
       {
-        if (progressline)
-        {
-          #pragma omp critical(stdio)
-          sout << '\n';
-          progressline = false;
-        }
+        progress.ClearLine();
         #pragma omp critical(stdio)
         sout << "No data found between offset " << lastmatchoffset
-          << " and " << filechecksummer.Offset() << std::endl;
+          << " and " << filechecksummer.Offset() << '\n';
+        progress.Print();
       }
 
       // Is this the first match
@@ -1854,42 +1795,34 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
     }
   }
 
-#ifdef _OPENMP
-  if (noiselevel > nlQuiet)
-  {
-    if (filechecksummer.Offset() == diskfile->FileSize()) {
-      #pragma omp atomic
-      mttotalprogress += filechecksummer.Offset() - oldoffset;
-    }
-  }
-#endif
-
   if (lastmatchoffset < filechecksummer.Offset() && noiselevel > nlNormal)
   {
-    if (progressline)
-    {
-      #pragma omp critical(stdio)
-      sout << '\n';
-    }
-
+    progress.ClearLine();
     #pragma omp critical(stdio)
     sout << "No data found between offset " << lastmatchoffset
       << " and " << filechecksummer.Offset() << std::endl;
+    progress.Print();
   }
+
+#ifdef _OPENMP
+  if (noiselevel > nlQuiet)
+  {
+    if (filechecksummer.Offset() == diskfile->FileSize())
+      progress.AddSilent(filechecksummer.Offset() - oldoffset);
+  }
+#endif
 
   // Get the Full and 16k hash values of the file
   filechecksummer.GetFileHashes(hashfull, hash16k);
 
   if (noiselevel >= nlDebug)
   {
+    progress.ClearLine();
     #pragma omp critical(stdio)
     {
-    // Clear out old scanning line
-    sout << std::setw(shortname.size()+19) << std::setfill(' ') << "";
-
     if (duplicatecount > 0)
-      sout << "\r[DEBUG] duplicates: " << duplicatecount << '\n';
-    sout << "\r[DEBUG] matchcount: " << count << "\n"
+      sout << "[DEBUG] duplicates: " << duplicatecount << '\n';
+    sout << "[DEBUG] matchcount: " << count << "\n"
       "[DEBUG] ----------------------" << std::endl;
     }
   }
@@ -2486,7 +2419,7 @@ bool Par2Repairer::AllocateBuffers(size_t memorylimit)
 }
 
 // Read source data, process it through the RS matrix and write it to disk.
-bool Par2Repairer::ProcessData(u64 blockoffset, size_t blocklength)
+bool Par2Repairer::ProcessData(u64 blockoffset, size_t blocklength, ProgressMeter<u64> &progress)
 {
   u64 totalwritten = 0;
 
@@ -2555,19 +2488,7 @@ bool Par2Repairer::ProcessData(u64 blockoffset, size_t blocklength)
         rs.Process(blocklength, inputindex, inputbuffer, internalOutputindex, outbuf);
 
         if (noiselevel > nlQuiet)
-        {
-          // Update a progress indicator
-          u32 oldfraction = (u32)(1000 * progress / totaldata);
-          #pragma omp atomic
-          progress += blocklength;
-          u32 newfraction = (u32)(1000 * progress / totaldata);
-
-          if (oldfraction != newfraction)
-          {
-            #pragma omp critical(stdio)
-            sout << "Repairing: " << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
-          }
-        }
+          progress.Add(blocklength);
       }
 
       ++inputblock;
@@ -2612,17 +2533,7 @@ bool Par2Repairer::ProcessData(u64 blockoffset, size_t blocklength)
       }
 
       if (noiselevel > nlQuiet)
-      {
-        // Update a progress indicator
-        u32 oldfraction = (u32)(1000 * progress / totaldata);
-        progress += blocklength;
-        u32 newfraction = (u32)(1000 * progress / totaldata);
-
-        if (oldfraction != newfraction)
-        {
-          sout << "Processing: " << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
-        }
-      }
+        progress.Add(blocklength);
 
       ++copyblock;
       ++inputblock;
@@ -2669,14 +2580,14 @@ bool Par2Repairer::VerifyTargetFiles(const std::string &basepath)
   std::sort(verifylist.begin(), verifylist.end(), SortSourceFilesByFileName);
 
 #ifdef _OPENMP
-  mttotalsize = 0;
-  mttotalprogress = 0;
+  u64 mttotalsize = 0;
 
   for (size_t i=0; i<verifylist.size(); ++i)
   {
     if (verifylist[i])
       mttotalsize += verifylist[i]->GetDescriptionPacket()->FileSize();
   }
+  ProgressMeter<u64> progress(sout, "Scanning: ", mttotalsize);
 #endif
 
   // Iterate through each file in the verification list
@@ -2709,7 +2620,7 @@ bool Par2Repairer::VerifyTargetFiles(const std::string &basepath)
     }
 
     // Verify the file again
-    if (!VerifyDataFile(targetfile, sourcefile, basepath))
+    if (!VerifyDataFile(targetfile, sourcefile, basepath MT_PROGRESS))
       finalresult = false;
 
     // Close the file again

--- a/src/par2repairer.h
+++ b/src/par2repairer.h
@@ -91,7 +91,11 @@ protected:
   bool VerifyExtraFiles(const std::vector<std::string> &extrafiles, const std::string &basepath, const bool renameonly);
 
   // Attempt to match the data in the DiskFile with the source file
-  bool VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const std::string &basepath, const bool renameonly = false);
+#ifdef _OPENMP
+  bool VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const std::string &basepath, ProgressMeter<u64> &progress, const bool renameonly = false);
+#else
+  bool VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const std::string &basepath, ProgressMeter<u64> &progress, const bool renameonly = false);
+#endif
 
   // Perform a sliding window scan of the DiskFile looking for blocks of data that
   // might belong to any of the source files (for which a verification packet was
@@ -100,6 +104,9 @@ protected:
   // found is for a different source file then "sourcefile" is changed accordingly.
   bool ScanDataFile(DiskFile                *diskfile,   // [in]     The file being scanned
                     std::string             basepath,    // [in]
+#ifdef _OPENMP
+                    ProgressMeter<u64>      &progress,   // [in]
+#endif
                     const bool              renameonly,  // [in]     Only look for perfect matches
                     Par2RepairerSourceFile* &sourcefile, // [in/out] The source file matched
                     MatchType               &matchtype,  // [out]    The type of match
@@ -129,7 +136,7 @@ protected:
   bool AllocateBuffers(size_t memorylimit);
 
   // Read source data, process it through the RS matrix and write it to disk.
-  bool ProcessData(u64 blockoffset, size_t blocklength);
+  bool ProcessData(u64 blockoffset, size_t blocklength, ProgressMeter<u64> &progress);
 
   // Verify that all of the reconstructed target files are now correct
   bool VerifyTargetFiles(const std::string &basepath);
@@ -206,15 +213,6 @@ protected:
 
   void                     *inputbuffer;             // Buffer for reading DataBlocks (chunksize)
   void                     *outputbuffer;            // Buffer for writing DataBlocks (chunksize * missingblockcount)
-
-  u64                       progress;                // How much data has been processed.
-  u64                       totaldata;               // Total amount of data to be processed.
-#ifdef _OPENMP
-  u64                       mttotalsize;             // Total size of files for mt-progress line
-  u64                       mttotalextrasize;        // Total size of extra files for mt-progress line
-  u64                       mttotalprogress;         // MT total progress
-  bool                      mtprocessingextrafiles;  // Are we currently processing extra files
-#endif
 };
 
 #endif // __PAR2REPAIRER_H__

--- a/src/par2repairer.h
+++ b/src/par2repairer.h
@@ -94,7 +94,7 @@ protected:
 #ifdef _OPENMP
   bool VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const std::string &basepath, ProgressMeter<u64> &progress, const bool renameonly = false);
 #else
-  bool VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const std::string &basepath, ProgressMeter<u64> &progress, const bool renameonly = false);
+  bool VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const std::string &basepath, const bool renameonly = false);
 #endif
 
   // Perform a sliding window scan of the DiskFile looking for blocks of data that

--- a/src/progressmeter.h
+++ b/src/progressmeter.h
@@ -106,7 +106,7 @@ public:
   void ClearLine()
   {
     #pragma omp critical(stdio)
-    sout << std::setw(message.size()+6) << std::setfill(' ') << "\r";
+    sout << std::setw(message.size()+7) << std::setfill(' ') << "\r";
   }
   void Print()
   {

--- a/src/progressmeter.h
+++ b/src/progressmeter.h
@@ -20,24 +20,50 @@
 #ifndef __PROGRESSMETER_H__
 #define __PROGRESSMETER_H__
 
+#include <chrono>
+
 template<typename TValue>
 class ProgressMeter
 {
+  using steady_clock = std::chrono::steady_clock;
+
   std::ostream &sout;
   std::string message;
   float scale;
   TValue current;
+  steady_clock::duration::rep printed;
 
   inline u32 CalcThousandths(TValue val)
   {
     return (u32)(scale * val);
   }
+  inline void PrintFraction(u32 fraction)
+  {
+    #pragma omp critical(stdio)
+    sout << message << fraction/10 << '.' << fraction%10 << "%\r" << std::flush;
+#if defined(_OPENMP) && _OPENMP >= 201107
+    #pragma omp atomic write
+#endif
+    printed = steady_clock::now().time_since_epoch().count();
+  }
+  inline bool ShouldUpdate(TValue oldval, TValue newval, u32 &newfraction)
+  {
+    newfraction = CalcThousandths(newval);
+    if (CalcThousandths(oldval) == newfraction)
+      return false;
+    steady_clock::duration::rep lastprinted;
+#if defined(_OPENMP) && _OPENMP >= 201107
+    #pragma omp atomic read
+#endif
+    lastprinted = printed;
+    return steady_clock::now() - steady_clock::time_point(steady_clock::duration(lastprinted)) >= std::chrono::milliseconds(50);
+  }
 
 public:
   ProgressMeter(std::ostream &sout, std::string &message, TValue total) :
-    sout(sout), message(message), scale(1000.0 / total), current(0) {}
+    sout(sout), message(message), scale(1000.0 / total), current(0), printed(0) {}
   ProgressMeter(std::ostream &sout, const char *message, TValue total) :
-    sout(sout), message(message), scale(1000.0 / total), current(0) {}
+    sout(sout), message(message), scale(1000.0 / total), current(0), printed(0) {}
 
   // NOTE: Update() doesn't always update current value, so don't mix it with Add()
   void Update(TValue newval)
@@ -47,12 +73,10 @@ public:
     #pragma omp atomic read
 #endif
     oldval = current;
-    u32 oldfraction = CalcThousandths(oldval);
-    u32 newfraction = CalcThousandths(newval);
-    if (oldfraction != newfraction)
+    u32 newfraction;
+    if (ShouldUpdate(oldval, newval, newfraction))
     {
-      #pragma omp critical(stdio)
-      sout << message << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
+      PrintFraction(newfraction);
 #if defined(_OPENMP) && _OPENMP >= 201107
       #pragma omp atomic write
 #endif
@@ -70,13 +94,9 @@ public:
     #pragma omp atomic
     current += amount;
 #endif
-    u32 oldfraction = CalcThousandths(newval - amount);
-    u32 newfraction = CalcThousandths(newval);
-    if (oldfraction != newfraction)
-    {
-      #pragma omp critical(stdio)
-      sout << message << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
-    }
+    u32 newfraction;
+    if (ShouldUpdate(newval - amount, newval, newfraction))
+      PrintFraction(newfraction);
   }
   inline void AddSilent(TValue amount)
   {
@@ -95,9 +115,7 @@ public:
     #pragma omp atomic read
 #endif
     val = current;
-    u32 fraction = CalcThousandths(val);
-    #pragma omp critical(stdio)
-    sout << message << fraction/10 << '.' << fraction%10 << "%\r" << std::flush;
+    PrintFraction(CalcThousandths(val));
   }
 };
 

--- a/src/progressmeter.h
+++ b/src/progressmeter.h
@@ -1,0 +1,105 @@
+//  This file is part of par2cmdline (a PAR 2.0 compatible file verification and
+//  repair tool). See http://parchive.sourceforge.net for details of PAR 2.0.
+//
+//  Copyright (c) 2003 Peter Brian Clements
+//
+//  par2cmdline is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  par2cmdline is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef __PROGRESSMETER_H__
+#define __PROGRESSMETER_H__
+
+template<typename TValue>
+class ProgressMeter
+{
+  std::ostream &sout;
+  std::string message;
+  TValue total;
+  TValue current;
+
+  inline u32 CalcThousandths(TValue val)
+  {
+    return (u32)(1000 * val / total);
+  }
+
+public:
+  ProgressMeter(std::ostream &sout, std::string &message, TValue total) :
+    sout(sout), message(message), total(total), current(0) {}
+  ProgressMeter(std::ostream &sout, const char *message, TValue total) :
+    sout(sout), message(message), total(total), current(0) {}
+
+  // NOTE: Update() doesn't always update current value, so don't mix it with Add()
+  void Update(TValue newval)
+  {
+    TValue oldval;
+#if defined(_OPENMP) && _OPENMP >= 201107
+    #pragma omp atomic read
+#endif
+    oldval = current;
+    u32 oldfraction = CalcThousandths(oldval);
+    u32 newfraction = CalcThousandths(newval);
+    if (oldfraction != newfraction)
+    {
+      #pragma omp critical(stdio)
+      sout << message << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
+#if defined(_OPENMP) && _OPENMP >= 201107
+      #pragma omp atomic write
+#endif
+      current = newval;
+    }
+  }
+  void Add(TValue amount)
+  {
+    TValue newval;
+#if defined(_OPENMP) && _OPENMP >= 201107
+    #pragma omp atomic capture
+    newval = current += amount;
+#else
+    newval = current + amount;
+    #pragma omp atomic
+    current += amount;
+#endif
+    u32 oldfraction = CalcThousandths(newval - amount);
+    u32 newfraction = CalcThousandths(newval);
+    if (oldfraction != newfraction)
+    {
+      #pragma omp critical(stdio)
+      sout << message << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
+    }
+  }
+  inline void AddSilent(TValue amount)
+  {
+    #pragma omp atomic
+    current += amount;
+  }
+  void ClearLine()
+  {
+    #pragma omp critical(stdio)
+    sout << std::setw(message.size()+6) << std::setfill(' ') << "\r";
+  }
+  void Print()
+  {
+    TValue val;
+#if defined(_OPENMP) && _OPENMP >= 201107
+    #pragma omp atomic read
+#endif
+    val = current;
+    u32 fraction = CalcThousandths(val);
+    #pragma omp critical(stdio)
+    sout << message << fraction/10 << '.' << fraction%10 << "%\r" << std::flush;
+  }
+};
+
+
+#endif // __PROGRESSMETER_H__

--- a/src/progressmeter.h
+++ b/src/progressmeter.h
@@ -36,7 +36,7 @@ class ProgressMeter
 
   inline u32 CalcThousandths(TValue val) const
   {
-    return (u32)(scale * val);
+    return (u32)(scale * val + 0.5f);
   }
   inline bool PrintFraction(TValue oldval, TValue newval)
   {
@@ -55,7 +55,7 @@ class ProgressMeter
     steady_clock::time_point now = steady_clock::now();
     steady_clock::time_point lastpoint = steady_clock::time_point(steady_clock::duration(lastprinted));
     // if enough time has passed, print the current progress, and update the time record
-    if (now - lastpoint >= INTERVAL)
+    if (now - lastpoint >= INTERVAL || newfraction == 1000)
     {
       #pragma omp critical(stdio)
       sout << message << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;

--- a/src/progressmeter.h
+++ b/src/progressmeter.h
@@ -28,12 +28,12 @@ class ProgressMeter
   using steady_clock = std::chrono::steady_clock;
 
   std::ostream &sout;
-  std::string message;
-  float scale;
+  const std::string message;
+  const float scale;
   TValue current;
   steady_clock::duration::rep printed;
 
-  inline u32 CalcThousandths(TValue val)
+  inline u32 CalcThousandths(TValue val) const
   {
     return (u32)(scale * val);
   }
@@ -46,7 +46,7 @@ class ProgressMeter
 #endif
     printed = steady_clock::now().time_since_epoch().count();
   }
-  inline bool ShouldUpdate(TValue oldval, TValue newval, u32 &newfraction)
+  inline bool ShouldUpdate(TValue oldval, TValue newval, u32 &newfraction) const
   {
     newfraction = CalcThousandths(newval);
     if (CalcThousandths(oldval) == newfraction)
@@ -60,10 +60,10 @@ class ProgressMeter
   }
 
 public:
-  ProgressMeter(std::ostream &sout, std::string &message, TValue total) :
-    sout(sout), message(message), scale(1000.0 / total), current(0), printed(0) {}
+  ProgressMeter(std::ostream &sout, const std::string &message, TValue total) :
+    sout(sout), message(message), scale(1000.0f / total), current(0), printed(0) {}
   ProgressMeter(std::ostream &sout, const char *message, TValue total) :
-    sout(sout), message(message), scale(1000.0 / total), current(0), printed(0) {}
+    sout(sout), message(message), scale(1000.0f / total), current(0), printed(0) {}
 
   // NOTE: Update() doesn't always update current value, so don't mix it with Add()
   void Update(TValue newval)

--- a/src/progressmeter.h
+++ b/src/progressmeter.h
@@ -25,19 +25,19 @@ class ProgressMeter
 {
   std::ostream &sout;
   std::string message;
-  TValue total;
+  float scale;
   TValue current;
 
   inline u32 CalcThousandths(TValue val)
   {
-    return (u32)(1000 * val / total);
+    return (u32)(scale * val);
   }
 
 public:
   ProgressMeter(std::ostream &sout, std::string &message, TValue total) :
-    sout(sout), message(message), total(total), current(0) {}
+    sout(sout), message(message), scale(1000.0 / total), current(0) {}
   ProgressMeter(std::ostream &sout, const char *message, TValue total) :
-    sout(sout), message(message), total(total), current(0) {}
+    sout(sout), message(message), scale(1000.0 / total), current(0) {}
 
   // NOTE: Update() doesn't always update current value, so don't mix it with Add()
   void Update(TValue newval)

--- a/src/progressmeter.h
+++ b/src/progressmeter.h
@@ -26,13 +26,13 @@ template<typename TValue>
 class ProgressMeter
 {
   using steady_clock = std::chrono::steady_clock;
-  const std::chrono::milliseconds INTERVAL = std::chrono::milliseconds(50);
+  const std::chrono::milliseconds PRINT_INTERVAL = std::chrono::milliseconds(50);
 
-  std::ostream &sout;
-  const std::string message;
-  const float scale;
-  TValue current;
-  steady_clock::duration::rep printed;
+  std::ostream &sout;        // stream for output (for commandline, this is cout)
+  const std::string message; // message to display alongside percentage
+  const float scale;         // pre-computed multiplier to convert progress value into a percentage*10
+  TValue current;            // last known progress value
+  steady_clock::duration::rep printed; // last time progress was outputted
 
   inline u32 CalcThousandths(TValue val) const
   {
@@ -54,8 +54,9 @@ class ProgressMeter
     
     steady_clock::time_point now = steady_clock::now();
     steady_clock::time_point lastpoint = steady_clock::time_point(steady_clock::duration(lastprinted));
+
     // if enough time has passed, print the current progress, and update the time record
-    if (now - lastpoint >= INTERVAL || newfraction == 1000)
+    if (now - lastpoint >= PRINT_INTERVAL || newfraction == 1000)
     {
       #pragma omp critical(stdio)
       sout << message << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
@@ -102,11 +103,6 @@ public:
     current += amount;
 #endif
     PrintFraction(newval - amount, newval);
-  }
-  inline void AddSilent(TValue amount)
-  {
-    #pragma omp atomic
-    current += amount;
   }
 
   // print a line whilst progress is still running

--- a/src/progressmeter.h
+++ b/src/progressmeter.h
@@ -26,6 +26,7 @@ template<typename TValue>
 class ProgressMeter
 {
   using steady_clock = std::chrono::steady_clock;
+  const std::chrono::milliseconds INTERVAL = std::chrono::milliseconds(50);
 
   std::ostream &sout;
   const std::string message;
@@ -37,26 +38,34 @@ class ProgressMeter
   {
     return (u32)(scale * val);
   }
-  inline void PrintFraction(u32 fraction)
+  inline bool PrintFraction(TValue oldval, TValue newval)
   {
-    #pragma omp critical(stdio)
-    sout << message << fraction/10 << '.' << fraction%10 << "%\r" << std::flush;
-#if defined(_OPENMP) && _OPENMP >= 201107
-    #pragma omp atomic write
-#endif
-    printed = steady_clock::now().time_since_epoch().count();
-  }
-  inline bool ShouldUpdate(TValue oldval, TValue newval, u32 &newfraction) const
-  {
-    newfraction = CalcThousandths(newval);
+    // if the displayed value won't change, don't print
+    u32 newfraction = CalcThousandths(newval);
     if (CalcThousandths(oldval) == newfraction)
       return false;
+
+    // check if enough time has passed
     steady_clock::duration::rep lastprinted;
 #if defined(_OPENMP) && _OPENMP >= 201107
     #pragma omp atomic read
 #endif
     lastprinted = printed;
-    return steady_clock::now() - steady_clock::time_point(steady_clock::duration(lastprinted)) >= std::chrono::milliseconds(50);
+    
+    steady_clock::time_point now = steady_clock::now();
+    steady_clock::time_point lastpoint = steady_clock::time_point(steady_clock::duration(lastprinted));
+    // if enough time has passed, print the current progress, and update the time record
+    if (now - lastpoint >= INTERVAL)
+    {
+      #pragma omp critical(stdio)
+      sout << message << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
+#if defined(_OPENMP) && _OPENMP >= 201107
+      #pragma omp atomic write
+#endif
+      printed = now.time_since_epoch().count();
+      return true;
+    }
+    return false;
   }
 
 public:
@@ -73,10 +82,8 @@ public:
     #pragma omp atomic read
 #endif
     oldval = current;
-    u32 newfraction;
-    if (ShouldUpdate(oldval, newval, newfraction))
+    if (PrintFraction(oldval, newval))
     {
-      PrintFraction(newfraction);
 #if defined(_OPENMP) && _OPENMP >= 201107
       #pragma omp atomic write
 #endif
@@ -94,28 +101,27 @@ public:
     #pragma omp atomic
     current += amount;
 #endif
-    u32 newfraction;
-    if (ShouldUpdate(newval - amount, newval, newfraction))
-      PrintFraction(newfraction);
+    PrintFraction(newval - amount, newval);
   }
   inline void AddSilent(TValue amount)
   {
     #pragma omp atomic
     current += amount;
   }
-  void ClearLine()
-  {
-    #pragma omp critical(stdio)
-    sout << std::setw(message.size()+7) << std::setfill(' ') << "\r";
-  }
-  void Print()
+
+  // print a line whilst progress is still running
+  void PrintLine(const std::string &line)
   {
     TValue val;
 #if defined(_OPENMP) && _OPENMP >= 201107
     #pragma omp atomic read
 #endif
     val = current;
-    PrintFraction(CalcThousandths(val));
+    u32 fraction = CalcThousandths(val);
+    #pragma omp critical(stdio)
+    sout << std::setw(message.size()+7) << std::setfill(' ') << "\r"
+      << line << '\n'
+      << message << fraction/10 << '.' << fraction%10 << "%\r" << std::flush;
   }
 };
 

--- a/src/reedsolomon.h
+++ b/src/reedsolomon.h
@@ -231,6 +231,8 @@ inline bool ReedSolomon<g>::Compute(NoiseLevel noiselevel, std::ostream &sout, s
   if (noiselevel > nlQuiet)
     sout << "Computing Reed Solomon matrix." << std::endl;
 
+  ProgressMeter<u32> progress(sout, "Constructing: ", datamissing+parmissing);
+
   /*  Layout of RS Matrix:
       NOTE: The second set of columns represents the parity vectors present,
       but this only uses datamissing of them.  Otherwise, it is over constrained.
@@ -269,14 +271,8 @@ inline bool ReedSolomon<g>::Compute(NoiseLevel noiselevel, std::ostream &sout, s
   // One row for each present recovery block that will be used for a missing data block
   for (unsigned int row=0; row<datamissing; row++)
   {
-    // Define MPDL to skip reporting and speed things up
-#ifndef MPDL
     if (noiselevel > nlQuiet)
-    {
-      int progress = row * 1000 / (datamissing+parmissing);
-      sout << "Constructing: " << progress/10 << '.' << progress%10 << "%\r" << std::flush;
-    }
-#endif
+      progress.Update(row);
 
     // Get the exponent of the next present recovery block
     while (!outputrow->present)
@@ -316,14 +312,8 @@ inline bool ReedSolomon<g>::Compute(NoiseLevel noiselevel, std::ostream &sout, s
   outputrow = outputrows.begin();
   for (unsigned int row=0; row<parmissing; row++)
   {
-    // Define MPDL to skip reporting and speed things up
-#ifndef MPDL
     if (noiselevel > nlQuiet)
-    {
-      int progress = (row+datamissing) * 1000 / (datamissing+parmissing);
-      sout << "Constructing: " << progress/10 << '.' << progress%10 << "%\r" << std::flush;
-    }
-#endif
+      progress.Update(row+datamissing);
 
     // Get the exponent of the next missing recovery block
     while (outputrow->present)
@@ -414,7 +404,7 @@ inline bool ReedSolomon<g>::GaussElim(NoiseLevel noiselevel, std::ostream &sout,
 
   // Solve one row at a time
 
-  int progress = 0;
+  ProgressMeter<u32> progress(sout, "Solving: ", datamissing*rows);
 
   // For each row in the matrix
   for (unsigned int row=0; row<datamissing; row++)
@@ -454,18 +444,8 @@ inline bool ReedSolomon<g>::GaussElim(NoiseLevel noiselevel, std::ostream &sout,
     // For every other row in the matrix
     for (unsigned int row2=0; row2<rows; row2++)
     {
-      // Define MPDL to skip reporting and speed things up
-#ifndef MPDL
       if (noiselevel > nlQuiet)
-      {
-        int newprogress = (row*rows+row2) * 1000 / (datamissing*rows);
-        if (progress != newprogress)
-        {
-          progress = newprogress;
-          sout << "Solving: " << progress/10 << '.' << progress%10 << "%\r" << std::flush;
-        }
-      }
-#endif
+        progress.Update(row*rows+row2);
 
       if (row != row2)
       {

--- a/src/reedsolomon.h
+++ b/src/reedsolomon.h
@@ -398,10 +398,11 @@ inline bool ReedSolomon<g>::GaussElim(NoiseLevel noiselevel, std::ostream &sout,
              << (unsigned int)rightmatrix[row*rows+col];
       }
       sout << ((row==0) ? " \\"   : (row==rows-1) ? " /"    : " | |");
-      sout << std::endl;
+      sout << '\n';
 
       sout << std::dec << std::setw(0) << std::setfill(' ');
     }
+    sout << std::flush;
   }
 
   // Because the matrices being operated on are Vandermonde matrices
@@ -533,10 +534,11 @@ inline bool ReedSolomon<g>::GaussElim(NoiseLevel noiselevel, std::ostream &sout,
              << (unsigned int)rightmatrix[row*rows+col];
       }
       sout << ((row==0) ? " \\"   : (row==rows-1) ? " /"    : " | |");
-      sout << std::endl;
+      sout << '\n';
 
       sout << std::dec << std::setw(0) << std::setfill(' ');
     }
+    sout << std::flush;
   }
 
   return true;

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -91,7 +91,7 @@ namespace utf8
     {
       std::cerr
         << "Too many arguments (" << argc << "/" << MAX_ARGS << ").\n"
-        << "Only " << MAX_ARGS << " will be processed." << std::endl;
+           "Only " << MAX_ARGS << " will be processed." << std::endl;
 
       m_argc = MAX_ARGS;
     }
@@ -103,7 +103,7 @@ namespace utf8
       {
         std::cerr
           << "Invalid argument: encountered nullptr in wargv.\n"
-          << "Skipping " << i << "argument." << std::endl;
+             "Skipping " << i << "argument." << std::endl;
         --m_argc;
         --i;
         continue;


### PR DESCRIPTION
This PR adds a number of small performance tweaks with printing output:

* remove some unnecessary stdout flushes by replacing some instances of `std::endl` with `\n`, and compile-time concatenate some constant strings
* for CLI, call `std::ios::sync_with_stdio(false)` to disable syncing with C's stdio
* add names to `omp critical` sections, which limits the scope of locks slightly (e.g. writing to console won't block adding to the `diskFileMap`)
* progress printing logic is abstracted to a new `ProgressMeter` class
  * this abstraction assumes multi-threading, even in cases where there's none. I expect the impact of this to be minimal
  * par2repairer's "No data found between offset" message behaviour has been changed slightly - current behaviour is to [preserve the progress line](https://github.com/Parchive/par2cmdline/blob/c745c6d3fbb064becc4ece2b255c6b9c12d4757c/src/par2repairer.cpp#L1735-L1740) and print a new one after the message, whilst the new behaviour doesn't preserve the old (stale) line
* the `MPDL` definition checks in reedsolomon.h are never defined, so I've removed them (I presume it to be functionally useless). I'm hoping the progress updates make this switch unnecessary
* restrict updating progress to every 50ms - this avoids excessive printing (commented in #293)
* most progress updates are performed at the end of a loop cycle, but [some](https://github.com/Parchive/par2cmdline/blob/c745c6d3fbb064becc4ece2b255c6b9c12d4757c/src/par1repairer.cpp#L817-L826) (like in repairer) are done at the beginning. Some of these have been moved to the loop end for consistency's sake

The time-based restriction on progress updates might be a little excessive, though it can have the biggest performance impact for shorter tasks.