### PR TITLE
Skip the redundant whole-file MD5 during verification

### DIFF
--- a/src/filechecksummer.cpp
+++ b/src/filechecksummer.cpp
@@ -32,11 +32,13 @@ static char THIS_FILE[]=__FILE__;
 
 FileCheckSummer::FileCheckSummer(DiskFile   *_diskfile,
                                  u64         _blocksize,
-                                 const u32 (&_windowtable)[256])
+                                 const u32 (&_windowtable)[256],
+                                 bool        _computefilehashes)
 : diskfile(_diskfile)
 , blocksize(_blocksize)
 , windowtable(_windowtable)
 , filesize(_diskfile->FileSize())
+, computefilehashes(_computefilehashes)
 , currentoffset(0)
 , buffer(0)
 , outpointer(0)
@@ -154,7 +156,8 @@ bool FileCheckSummer::Fill(bool longfill)
     if (!diskfile->Read(readoffset, tailpointer, want))
       return false;
 
-    UpdateHashes(readoffset, tailpointer, want);
+    if (computefilehashes)
+      UpdateHashes(readoffset, tailpointer, want);
     readoffset += want;
     tailpointer += want;
   }
@@ -203,6 +206,8 @@ void FileCheckSummer::UpdateHashes(u64 offset, const void *buffer, size_t length
 // Return the full file hash and the 16k file hash
 void FileCheckSummer::GetFileHashes(MD5Hash &hashfull, MD5Hash &hash16k) const
 {
+  assert(computefilehashes);
+
   // Compute the hash of the first 16k
   MD5Context context = context16k;
   context.Final(hash16k);

--- a/src/filechecksummer.h
+++ b/src/filechecksummer.h
@@ -39,7 +39,8 @@ class FileCheckSummer
 public:
   FileCheckSummer(DiskFile   *diskfile,
                   u64         blocksize,
-                  const u32 (&windowtable)[256]);
+                  const u32 (&windowtable)[256],
+                  bool        computefilehashes = true);
   ~FileCheckSummer(void);
 
   // Start reading the file at the beginning
@@ -68,7 +69,8 @@ public:
   // Return the current file offset
   u64 Offset(void) const;
 
-  // Return the full file hash and the 16k file hash
+  // Return the full file hash and the 16k file hash.
+  // Only valid if the checksummer was constructed with computefilehashes set.
   void GetFileHashes(MD5Hash &hashfull, MD5Hash &hash16k) const;
 
   // Which disk file is this
@@ -80,6 +82,9 @@ protected:
   const u32 (&windowtable)[256];
 
   u64         filesize;
+
+  // Whether to compute the MD5 hash of the whole file and of the first 16k
+  bool        computefilehashes;
 
   u64         currentoffset; // file offset for current window position
   char       *buffer;        // buffer for reading from the file

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -1559,8 +1559,8 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
                                 const bool              renameonly,   // [in]
                                 Par2RepairerSourceFile* &sourcefile,  // [in/out]
                                 MatchType               &matchtype,   // [out]
-                                MD5Hash                 &hashfull,    // [out]
-                                MD5Hash                 &hash16k,     // [out]
+                                MD5Hash                 &hashfull,    // [out] only set if there are unverifiable source files
+                                MD5Hash                 &hash16k,     // [out] only set if there are unverifiable source files
                                 u32                     &count)       // [out]
 {
   // Remember which file we wanted to match
@@ -1595,8 +1595,13 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
     shortname = name;
   }
 
+  // The MD5 hash of the whole file is only needed to match against source
+  // files which have no verification packet. Every block matched below has
+  // had its own MD5 checked, so a full match implies the whole file hash.
+  const bool computefilehashes = !unverifiablesourcefiles.empty();
+
   // Create the checksummer for the file and start reading from it
-  FileCheckSummer filechecksummer(diskfile, blocksize, windowtable);
+  FileCheckSummer filechecksummer(diskfile, blocksize, windowtable, computefilehashes);
   if (!filechecksummer.Start())
     return false;
 
@@ -1811,7 +1816,8 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
   }
 
   // Get the Full and 16k hash values of the file
-  filechecksummer.GetFileHashes(hashfull, hash16k);
+  if (computefilehashes)
+    filechecksummer.GetFileHashes(hashfull, hash16k);
 
   if (noiselevel >= nlDebug)
   {
@@ -1826,13 +1832,14 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
   // Did we make any matches at all
   if (count > 0)
   {
-    // If this still might be a perfect match, check the
-    // hashes, file size, and number of blocks to confirm.
+    // If this still might be a perfect match, check the file size and
+    // number of blocks to confirm. The file hashes need not be checked:
+    // a full match means every block of the file was matched, in order,
+    // starting at offset 0, and each of those matches required the MD5
+    // hash of the block to be verified.
     if (matchtype            != eFullMatch ||
         count                != sourcefile->GetVerificationPacket()->BlockCount() ||
-        diskfile->FileSize() != sourcefile->GetDescriptionPacket()->FileSize() ||
-        hashfull             != sourcefile->GetDescriptionPacket()->HashFull() ||
-        hash16k              != sourcefile->GetDescriptionPacket()->Hash16k())
+        diskfile->FileSize() != sourcefile->GetDescriptionPacket()->FileSize())
     {
       matchtype = ePartialMatch;
 


### PR DESCRIPTION
Verification hashes every byte twice: once for the block it belongs to, and again for the whole-file MD5. The second one tells us nothing new; if every block matches and the file is the right length, the whole-file hash cannot be wrong. MD5 is slow and does not vectorise over a single stream, so dropping that second pass is worth a lot.

`FileCheckSummer` now only computes the whole-file and 16k hashes when something can actually use them, which is when a source file has no verification packet and no blocks are found at all. The full-match check falls back to the file size and block count, which a full match already guarantees.

| | before | after |
|---|---|---|
| 1 GB intact, single file | 6.14 s | 4.70 s |
| 1 GB with three damaged regions | 6.16 s | 4.71 s |
| 8 × 128 MB intact | 3.22 s | 2.50 s |

There is no otherwise behaviour change verify still reports the same, since it only drops a check that a full match already implies.

Verify output against master for intact files, damage at the start, middle and end, truncation, and renamed and extra files.