### PR TITLE
Verify the blocks of a file in parallel

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -179,6 +179,8 @@ EXTRA_DIST = \
 	tests/test42.ps1 \
 	tests/test43 \
 	tests/test44 \
+	tests/test45 \
+	tests/test45.ps1 \
 	tests/unit_tests \
 	tests/unit_tests.ps1
 
@@ -263,6 +265,7 @@ TESTS = \
 	tests/test42 \
 	tests/test43 \
 	tests/test44 \
+	tests/test45 \
 	tests/utf8_test \
 	tests/unit_tests
 

--- a/config.h.in
+++ b/config.h.in
@@ -34,6 +34,9 @@
 /* Define to 1 if you have the <ndir.h> header file, and it defines 'DIR'. */
 #undef HAVE_NDIR_H
 
+/* Define to 1 if you have the 'posix_fadvise' function. */
+#undef HAVE_POSIX_FADVISE
+
 /* Define to 1 if you have the 'pread' function. */
 #undef HAVE_PREAD
 

--- a/config.h.in
+++ b/config.h.in
@@ -34,6 +34,9 @@
 /* Define to 1 if you have the <ndir.h> header file, and it defines 'DIR'. */
 #undef HAVE_NDIR_H
 
+/* Define to 1 if you have the 'pread' function. */
+#undef HAVE_PREAD
+
 /* Define to 1 if stdbool.h conforms to C99. */
 #undef HAVE_STDBOOL_H
 

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,20 @@ dnl Checks for library functions.
 AC_FUNC_MEMCMP
 AC_CHECK_FUNCS([stricmp] [strcasecmp])
 AC_CHECK_FUNCS([strchr] [memcpy])
+AC_CHECK_FUNCS([pread])
+
+dnl DiskFile::Read is given the position to read from, using ReadFile with an
+dnl OVERLAPPED offset on Windows and pread everywhere else. Without one of the
+dnl two a file cannot be read from several threads at once.
+AC_MSG_CHECKING([whether a file can be read at an explicit offset])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#if !defined(_WIN32) && !defined(HAVE_PREAD)
+#error no positional read
+#endif
+]])],
+  [AC_MSG_RESULT([yes])],
+  [AC_MSG_RESULT([no])
+   AC_MSG_ERROR([par2cmdline needs pread, or the Windows API, to read a file at an explicit offset])])
 
 AC_CHECK_FUNCS([getopt] [getopt_long])
 

--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,7 @@ AC_FUNC_MEMCMP
 AC_CHECK_FUNCS([stricmp] [strcasecmp])
 AC_CHECK_FUNCS([strchr] [memcpy])
 AC_CHECK_FUNCS([pread])
+AC_CHECK_FUNCS([posix_fadvise])
 
 dnl DiskFile::Read is given the position to read from, using ReadFile with an
 dnl OVERLAPPED offset on Windows and pread everywhere else. Without one of the

--- a/man/par2.1
+++ b/man/par2.1
@@ -62,7 +62,12 @@ Memory (in MB) to use (default is half of total physical memory)
 .RB "Number of threads used for main processing (default auto-detected)"
 .TP
 .B \-T<n>
-.RB "Number of files hashed in parallel (default 2)"
+.RB "Number of files hashed in parallel (default 2)."
+Threads which are not busy with another file also share out the blocks of a
+single file, so that one large file is not left to a single thread while the
+others have finished. No more threads are used in total than this option asks
+for. Each block is checked where it is expected to be, and only the parts of a
+file whose blocks are not there are searched a byte at a time afterwards
 .TP
 .B \-\-
 Treat all following arguments as filenames

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -118,8 +118,9 @@ void CommandLine::usage(void)
 #ifdef _OPENMP
   std::cout <<
     "  -t<n>    : Number of threads used for main processing (" << omp_get_max_threads() << " detected)\n"
-    "  -T<n>    : Number of files hashed in parallel\n"
-    "             (" << _FILE_THREADS << " are the default)\n";
+    "  -T<n>    : Number of files hashed in parallel (" << _FILE_THREADS << " are the default)\n"
+    "             Threads not busy with another file share out the blocks of a\n"
+    "             single file, so that one large file is not left to a single thread\n";
 #endif
   std::cout <<
     "  --       : Treat all following arguments as filenames\n"

--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -440,17 +440,15 @@ bool DiskFile::FileExists(std::string filename)
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #ifdef HAVE_FSEEKO
-# define OffsetType off_t
-# define MaxOffset ((off_t)0x7fffffffffffffffULL)
 # define fseek fseeko
+#endif
+
+#define OffsetType off_t
+
+#if defined(HAVE_FSEEKO) || (_FILE_OFFSET_BITS == 64)
+# define MaxOffset ((OffsetType)0x7fffffffffffffffULL)
 #else
-# if _FILE_OFFSET_BITS == 64
-#  define OffsetType unsigned long long
-#  define MaxOffset 0x7fffffffffffffffULL
-# else
-#  define OffsetType long
-#  define MaxOffset 0x7fffffffUL
-# endif
+# define MaxOffset ((OffsetType)0x7fffffffUL)
 #endif
 
 
@@ -671,13 +669,13 @@ void DiskFile::Prefetch(u64 _offset, u64 _length)
     return;
 
 #if defined(HAVE_POSIX_FADVISE)
-  posix_fadvise(fileno(file), (off_t)_offset, (off_t)_length, POSIX_FADV_WILLNEED);
+  posix_fadvise(fileno(file), (OffsetType)_offset, (OffsetType)_length, POSIX_FADV_WILLNEED);
 #elif defined(F_RDADVISE)
   // The count is only an int, so a longer range has to be asked for in pieces
   while (_length > 0)
   {
     struct radvisory ra;
-    ra.ra_offset = (off_t)_offset;
+    ra.ra_offset = (OffsetType)_offset;
     ra.ra_count = (int)std::min(_length, (u64)1 << 30);
 
     if (fcntl(fileno(file), F_RDADVISE, &ra) == -1)
@@ -714,7 +712,7 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxleng
     else
       want = length;
 
-    ssize_t got = pread(fd, buffer, want, (off_t)_offset);
+    ssize_t got = pread(fd, buffer, want, (OffsetType)_offset);
     if (got != (ssize_t)want)
     {
       // NOTE: This can happen on error or when hitting the end-of-file.

--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -279,25 +279,6 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxleng
 {
   assert(hFile != INVALID_HANDLE_VALUE);
 
-  if (offset != _offset)
-  {
-    LONG* ptroffset = (LONG*)&_offset;
-    LONG lowoffset = ptroffset[0];
-    LONG highoffset = ptroffset[1];
-
-    // Seek to the required offset
-    if (INVALID_SET_FILE_POINTER == SetFilePointer(hFile, lowoffset, &highoffset, FILE_BEGIN))
-    {
-      DWORD error = ::GetLastError();
-
-      #pragma omp critical(stdio)
-      *serr << "Could not read " << (u64)length << " bytes from \"" << filename << "\" at offset " << _offset << ": " << ErrorMessage(error) << std::endl;
-
-      return false;
-    }
-    offset = _offset;
-  }
-
   while (length > 0) {
 
     DWORD want;
@@ -307,8 +288,17 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxleng
       want = (LengthType)length;
     DWORD got = 0;
 
+    // Read from the given position without using the handle's file pointer
+    ULARGE_INTEGER position;
+    position.QuadPart = (ULONGLONG)_offset;
+
+    OVERLAPPED overlapped;
+    memset(&overlapped, 0, sizeof(overlapped));
+    overlapped.Offset = position.LowPart;
+    overlapped.OffsetHigh = position.HighPart;
+
     // Read the data
-    if (!::ReadFile(hFile, buffer, want, &got, NULL))
+    if (!::ReadFile(hFile, buffer, want, &got, &overlapped))
     {
       DWORD error = ::GetLastError();
 
@@ -318,17 +308,23 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxleng
       return false;
     }
 
+    if (got == 0)
+    {
+      #pragma omp critical(stdio)
+      *serr << "Could not read " << (u64)length << " bytes from \"" << filename << "\" at offset " << _offset << ": unexpected end of file." << std::endl;
+
+      return false;
+    }
+
     if (want != got)
     {
       #pragma omp critical(stdio)
-      *serr << "Incomplete read from \"" << filename << "\" at offset " << offset << ".  Tried to read " << want << " bytes and received " << got << " bytes." << std::endl;
+      *serr << "Incomplete read from \"" << filename << "\" at offset " << _offset << ".  Tried to read " << want << " bytes and received " << got << " bytes." << std::endl;
     }
 
-    offset += got;
+    _offset += got;
     length -= got;
     buffer = ((char *) buffer) + got;
-
-    // write updates filesize.  Do we want to do that here?
   }
 
   return true;
@@ -665,25 +661,14 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxleng
 {
   assert(file != 0);
 
-  if (offset != _offset)
+  if (_offset > (u64)MaxOffset)
   {
-    if (_offset > (u64)MaxOffset)
-    {
-      #pragma omp critical(stdio)
-      *serr << "Could not read " << (u64)length << " bytes from " << filename << " at offset " << _offset << std::endl;
-      return false;
-    }
-
-
-    if (fseek(file, (OffsetType)_offset, SEEK_SET))
-    {
-      #pragma omp critical(stdio)
-      *serr << "Could not read " << (u64)length << " bytes from " << filename << " at offset " << _offset << ": " << strerror(errno) << std::endl;
-      return false;
-    }
-    offset = _offset;
+    #pragma omp critical(stdio)
+    *serr << "Could not read " << (u64)length << " bytes from " << filename << " at offset " << _offset << std::endl;
+    return false;
   }
 
+  int fd = fileno(file);
 
   while (length > 0) {
 
@@ -693,8 +678,8 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxleng
     else
       want = length;
 
-    LengthType got = fread(buffer, 1, want, file);
-    if (got != want)
+    ssize_t got = pread(fd, buffer, want, (off_t)_offset);
+    if (got != (ssize_t)want)
     {
       // NOTE: This can happen on error or when hitting the end-of-file.
 
@@ -703,11 +688,9 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxleng
       return false;
     }
 
-    offset += got;
+    _offset += got;
     length -= got;
     buffer = ((char *) buffer) + got;
-
-    // Write() updates filesize.  Should we do that here too?
   }
 
   return true;

--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -444,12 +444,7 @@ bool DiskFile::FileExists(std::string filename)
 #endif
 
 #define OffsetType off_t
-
-#if defined(HAVE_FSEEKO) || (_FILE_OFFSET_BITS == 64)
-# define MaxOffset ((OffsetType)0x7fffffffffffffffULL)
-#else
-# define MaxOffset ((OffsetType)0x7fffffffUL)
-#endif
+#define MaxOffset ((std::numeric_limits<OffsetType>::max)())
 
 
 DiskFile::DiskFile(std::ostream &sout, std::ostream &serr)

--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -273,6 +273,12 @@ bool DiskFile::Open(const std::string &_filename, u64 _filesize)
   return true;
 }
 
+// Ask the system to begin reading a range of the file into its cache
+
+void DiskFile::Prefetch(u64, u64)
+{
+}
+
 // Read some data from disk
 
 bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxlength)
@@ -653,6 +659,36 @@ bool DiskFile::Open(const std::string &_filename, u64 _filesize)
   exists = true;
 
   return true;
+}
+
+// Ask the system to begin reading a range of the file into its cache
+
+void DiskFile::Prefetch(u64 _offset, u64 _length)
+{
+  assert(file != 0);
+
+  if (_length == 0)
+    return;
+
+#if defined(HAVE_POSIX_FADVISE)
+  posix_fadvise(fileno(file), (off_t)_offset, (off_t)_length, POSIX_FADV_WILLNEED);
+#elif defined(F_RDADVISE)
+  // The count is only an int, so a longer range has to be asked for in pieces
+  while (_length > 0)
+  {
+    struct radvisory ra;
+    ra.ra_offset = (off_t)_offset;
+    ra.ra_count = (int)std::min(_length, (u64)1 << 30);
+
+    if (fcntl(fileno(file), F_RDADVISE, &ra) == -1)
+      break;
+
+    _offset += (u64)ra.ra_count;
+    _length -= (u64)ra.ra_count;
+  }
+#else
+  (void)_offset;
+#endif
 }
 
 // Read some data from disk

--- a/src/diskfile.h
+++ b/src/diskfile.h
@@ -76,6 +76,10 @@ public:
   bool Read(u64 offset, void *buffer, size_t length,
 	    LengthType maxlength = MAX_LENGTH);
 
+  // Ask the system to begin reading a range of the file into its cache. This
+  // is only a hint and does nothing on a system which cannot be told.
+  void Prefetch(u64 offset, u64 length);
+
   // Close the file
   void Close(void);
 

--- a/src/diskfile.h
+++ b/src/diskfile.h
@@ -131,7 +131,7 @@ protected:
   FILE *file;
 #endif
 
-  // Current offset within the file
+  // Current write offset within the file. Read() neither uses nor updates it.
   u64    offset;
 
   // Does the file exist

--- a/src/filechecksummer.cpp
+++ b/src/filechecksummer.cpp
@@ -57,10 +57,12 @@ FileCheckSummer::~FileCheckSummer(void)
   delete [] buffer;
 }
 
-// Start reading the file at the beginning
-bool FileCheckSummer::Start(void)
+// Start reading the file at the beginning, or at the given offset
+bool FileCheckSummer::Start(u64 startoffset)
 {
-  currentoffset = readoffset = 0;
+  assert(startoffset == 0 || !computefilehashes);
+
+  currentoffset = readoffset = startoffset;
 
   tailpointer = outpointer = buffer;
   inpointer = &buffer[blocksize];

--- a/src/filechecksummer.h
+++ b/src/filechecksummer.h
@@ -43,8 +43,9 @@ public:
                   bool        computefilehashes = true);
   ~FileCheckSummer(void);
 
-  // Start reading the file at the beginning
-  bool Start(void);
+  // Start reading the file at the beginning, or at the given offset. The
+  // whole file and 16k hashes can only be computed when starting at 0.
+  bool Start(u64 startoffset = 0);
 
   // Jump ahead the specified distance
   bool Jump(u64 distance);

--- a/src/libpar2internal.h
+++ b/src/libpar2internal.h
@@ -189,6 +189,7 @@ typedef unsigned int     size_t;
 #include <sstream>
 #include <algorithm>
 #include <memory>
+#include <limits>
 
 #include <ctype.h>
 #include <iomanip>

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -1613,6 +1613,11 @@ bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [i
     const int first = static_cast<int>(blocknumber);
     const int last  = static_cast<int>(std::min((u64)blockcount, (u64)blocknumber + threads * 4));
 
+    // Reading a chunk in one go keeps the disk sequential, where the threads
+    // reading their own parts of it at the same time would not
+    const u64 chunkstart = (u64)first * blocksize;
+    diskfile->Prefetch(chunkstart, std::min(filesize, (u64)last * blocksize) - chunkstart);
+
 #ifdef _OPENMP
     #pragma omp parallel num_threads(threads)
 #endif

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -39,6 +39,7 @@ static char THIS_FILE[]=__FILE__;
 #ifdef _OPENMP
 u32 Par2Repairer::filethreads = _FILE_THREADS;
 #endif
+std::atomic<u32> Par2Repairer::activeblockscans(0);
 
 
 Par2Repairer::Par2Repairer(std::ostream &sout, std::ostream &serr, const NoiseLevel noiselevel)
@@ -152,6 +153,12 @@ Result Par2Repairer::Process(
   // Set the number of threads
   if (nthreads != 0)
     omp_set_num_threads(nthreads);
+
+  // Files are scanned in parallel, and so are the blocks within one file,
+  // so both levels need to be able to run threads.
+#if _OPENMP >= 200805
+  omp_set_max_active_levels(2);
+#endif
 #endif
 
   // Determine the searchpath from the location of the main PAR2 file
@@ -1546,6 +1553,131 @@ bool Par2Repairer::VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *so
   return true;
 }
 
+// Check every block of a source file at the offset where it is expected to be.
+// Nothing is recorded here: the caller is told which blocks were found.
+bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [in]
+                                       ProgressMeter<u64>     &progress,   // [in]
+                                       Par2RepairerSourceFile *sourcefile, // [in]
+                                       std::vector<char>      &matched,    // [out]
+                                       u32                    &matchcount) // [out]
+{
+  matchcount = 0;
+
+  // We must know which source file the data is supposed to belong to
+  if (0 == sourcefile)
+    return false;
+
+  VerificationPacket *verificationpacket = sourcefile->GetVerificationPacket();
+  if (0 == verificationpacket)
+    return false;
+
+  // A source file which has already been matched must not claim its blocks again
+  if (0 != sourcefile->GetCompleteFile())
+    return false;
+
+  // Unless the file is exactly the right length it cannot be a perfect match
+  const u64 filesize = sourcefile->GetDescriptionPacket()->FileSize();
+  if (diskfile->FileSize() != filesize)
+    return false;
+
+  const u32 blockcount = verificationpacket->BlockCount();
+  if (0 == blockcount)
+    return false;
+
+  matched.assign(blockcount, 0);
+
+  // The file threads are the whole budget, so the threads not being spent on
+  // another file are shared out between the blocks of this one
+#ifdef _OPENMP
+  const u32 budget = filethreads;
+#else
+  const u32 budget = 1;
+#endif
+
+  ++activeblockscans;
+
+  // The file is checked a chunk of blocks at a time, so that the number of
+  // threads can be raised again each time another file finishes
+  u32 blocknumber = 0;
+
+  while (blocknumber < blockcount)
+  {
+    u32 scanning = activeblockscans.load();
+    if (scanning < 1)
+      scanning = 1;
+
+    u32 threads = budget / scanning;
+    if (threads < 1)
+      threads = 1;
+
+    const int first = static_cast<int>(blocknumber);
+    const int last  = static_cast<int>(std::min((u64)blockcount, (u64)blocknumber + threads * 4));
+
+#ifdef _OPENMP
+    #pragma omp parallel num_threads(threads)
+#endif
+    {
+      std::vector<char> buffer((size_t)blocksize);
+
+      // Every block costs the same, so each thread takes a run of consecutive
+      // blocks and its reads stay in order
+#ifdef _OPENMP
+      #pragma omp for schedule(static)
+#endif
+      for (int b=first; b<last; ++b)
+      {
+        const u64 offset = (u64)b * blocksize;
+        const u64 length = std::min(blocksize, filesize - offset);
+
+        bool blockmatched = diskfile->Read(offset, &buffer[0], (size_t)length);
+
+        if (blockmatched)
+        {
+          // The verification entry for the last block of a file covers the
+          // block padded out to the full block size with zeroes
+          if (length < blocksize)
+            memset(&buffer[length], 0, (size_t)(blocksize - length));
+
+          const FILEVERIFICATIONENTRY *entry = verificationpacket->VerificationEntry(b);
+
+          u32 checksum = ~0 ^ CRCUpdateBlock(~0, (size_t)blocksize, &buffer[0]);
+
+          blockmatched = checksum == entry->crc;
+
+          if (blockmatched)
+          {
+            MD5Context context;
+            context.Update(&buffer[0], (size_t)blocksize);
+
+            MD5Hash hash;
+            context.Final(hash);
+
+            blockmatched = hash == entry->hash;
+          }
+        }
+
+        if (!blockmatched)
+          continue;
+
+        matched[b] = 1;
+
+        if (noiselevel > nlQuiet)
+          progress.Add(length);
+      }
+    }
+
+    blocknumber = static_cast<u32>(last);
+  }
+
+  --activeblockscans;
+
+  for (u32 b=0; b<blockcount; ++b)
+    if (matched[b])
+      matchcount++;
+
+  return true;
+}
+
 // Perform a sliding window scan of the DiskFile looking for blocks of data that
 // might belong to any of the source files (for which a verification packet was
 // available). If a block of data might be from more than one source file, prefer
@@ -1595,15 +1727,17 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
     shortname = name;
   }
 
-  // The MD5 hash of the whole file is only needed to match against source
-  // files which have no verification packet. Every block matched below has
-  // had its own MD5 checked, so a full match implies the whole file hash.
-  const bool computefilehashes = !unverifiablesourcefiles.empty();
-
-  // Create the checksummer for the file and start reading from it
-  FileCheckSummer filechecksummer(diskfile, blocksize, windowtable, computefilehashes);
-  if (!filechecksummer.Start())
-    return false;
+#ifdef _OPENMP
+  if (noiselevel > nlQuiet)
+  {
+    #pragma omp critical(stdio)
+    sout << "Opening: \"" << shortname << "\"" << std::endl;
+  }
+#else
+  std::string message = "Scanning: \"";
+  message.append(shortname).append("\": ");
+  ProgressMeter<u64> progress(sout, message, diskfile->FileSize());
+#endif
 
   // Assume we will make a perfect match for the file
   matchtype = eFullMatch;
@@ -1617,8 +1751,87 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
   // Have we found data blocks in this file that belong to more than one target file
   bool multipletargets = false;
 
-  // Which block do we expect to find first
-  const VerificationHashEntry *nextentry = 0;
+  // Total number of bytes that were skipped whilst scanning
+  u64 skippeddata = 0;
+
+  const u64 filesize = diskfile->FileSize();
+
+  std::vector<char> alignedmatch;
+  u32 alignedcount = 0;
+  const bool aligned = ScanDataFileAligned(diskfile, progress, sourcefile,
+                                           alignedmatch, alignedcount);
+
+  // The parts of the file which still have to be searched a byte at a time
+  std::vector<std::pair<u64, u64> > searchranges;
+
+  if (aligned && alignedcount > 0)
+  {
+    const u32 blockcount = (u32)alignedmatch.size();
+
+    // Record the blocks which were found where they were expected. Their
+    // lengths were set when the source file was given its data blocks.
+    std::vector<DataBlock>::iterator sb = sourcefile->SourceBlocks();
+
+    for (u32 blocknumber=0; blocknumber<blockcount; ++blocknumber)
+    {
+      if (alignedmatch[blocknumber])
+      {
+        if (blocksallocated)
+          (*sb).SetLocation(diskfile, (u64)blocknumber * blocksize);
+
+        count++;
+      }
+
+      ++sb;
+    }
+
+    if (alignedcount < blockcount)
+    {
+      matchtype = ePartialMatch;
+
+      // In rename-only mode, skip files that are not perfect matches
+      if (renameonly)
+        return true;
+
+      // Search each run of blocks which was not where it was expected. The
+      // blocks on either side of a run have been claimed already, so nothing
+      // outside these ranges is left to find.
+      for (u32 blocknumber=0; blocknumber<blockcount; )
+      {
+        if (alignedmatch[blocknumber])
+        {
+          ++blocknumber;
+          continue;
+        }
+
+        const u32 gapfirst = blocknumber;
+        while (blocknumber < blockcount && !alignedmatch[blocknumber])
+          ++blocknumber;
+
+        searchranges.push_back(std::make_pair((u64)gapfirst * blocksize,
+                                              std::min(filesize, (u64)blocknumber * blocksize)));
+      }
+    }
+  }
+  else
+  {
+    // Nothing is known about where the data is, so search all of it
+    searchranges.push_back(std::make_pair((u64)0, filesize));
+  }
+
+  if (!searchranges.empty())
+  {
+
+  // The MD5 hash of the whole file is only needed to match against source
+  // files which have no verification packet, and only when no block at all is
+  // found. That can only happen when the whole of the file is being searched.
+  const bool computefilehashes = !unverifiablesourcefiles.empty()
+                                 && 1 == searchranges.size()
+                                 && 0 == searchranges[0].first
+                                 && filesize == searchranges[0].second;
+
+  // Create the checksummer for the file
+  FileCheckSummer filechecksummer(diskfile, blocksize, windowtable, computefilehashes);
 
   // How far will we scan the file (1 byte at a time)
   // before skipping ahead looking for the next block
@@ -1627,32 +1840,29 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
   // Distance to skip forward if we don't find a block
   u64 scanskip = skipdata ? blocksize - scandistance : 0;
 
+  for (size_t range=0; range<searchranges.size(); ++range)
+  {
+  const u64 rangestart = searchranges[range].first;
+  const u64 rangeend = searchranges[range].second;
+
+  if (!filechecksummer.Start(rangestart))
+    return false;
+
+  // Which block do we expect to find first. Nothing is suggested at the start
+  // of a range, just as nothing is suggested after a block is not found.
+  const VerificationHashEntry *nextentry = 0;
+
   // Assume with are half way through scanning
   u64 scanoffset = scandistance >> 1;
 
-  // Total number of bytes that were skipped whilst scanning
-  u64 skippeddata = 0;
-
   // Offset of last data that was found
-  u64 lastmatchoffset = 0;
+  u64 lastmatchoffset = rangestart;
 
-  u64 oldoffset = 0;
+  u64 oldoffset = rangestart;
   u64 printprogress = 0;
 
-#ifdef _OPENMP
-  if (noiselevel > nlQuiet)
-  {
-    #pragma omp critical(stdio)
-    sout << "Opening: \"" << shortname << "\"" << std::endl;
-  }
-#else
-  std::string message = "Scanning: \"";
-  message.append(shortname).append("\": ");
-  ProgressMeter<u64> progress(sout, message, diskfile->FileSize());
-#endif
-
-  // Whilst we have not reached the end of the file
-  while (filechecksummer.Offset() < diskfile->FileSize())
+  // Whilst we have not reached the end of the range
+  while (filechecksummer.Offset() < rangeend)
   {
     if (noiselevel > nlQuiet)
     {
@@ -1784,7 +1994,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
         // Have we scanned too far without finding a block?
         if (scanskip > 0
             && ++scanoffset >= scandistance
-            && skipfrom < diskfile->FileSize())
+            && skipfrom < rangeend)
         {
           // Skip forwards to where we think we might find more data
           if (!filechecksummer.Jump(scanskip))
@@ -1803,7 +2013,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
 #ifdef _OPENMP
   if (noiselevel > nlQuiet)
   {
-    if (filechecksummer.Offset() == diskfile->FileSize())
+    if (filechecksummer.Offset() >= rangeend)
       progress.Add(filechecksummer.Offset() - oldoffset);
   }
 #endif
@@ -1815,9 +2025,13 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
       << " and " << filechecksummer.Offset()).str());
   }
 
+  }
+
   // Get the Full and 16k hash values of the file
   if (computefilehashes)
     filechecksummer.GetFileHashes(hashfull, hash16k);
+
+  }
 
   if (noiselevel >= nlDebug)
   {

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -1873,7 +1873,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
     {
       // Update progress indicator
       printprogress += filechecksummer.Offset() - oldoffset;
-      if (printprogress == blocksize || filechecksummer.ShortBlock())
+      if (printprogress >= blocksize || filechecksummer.ShortBlock())
       {
         progress.Add(printprogress);
         printprogress = 0;

--- a/src/par2repairer.h
+++ b/src/par2repairer.h
@@ -21,6 +21,7 @@
 #ifndef __PAR2REPAIRER_H__
 #define __PAR2REPAIRER_H__
 
+#include <atomic>
 
 class Par2Repairer
 {
@@ -97,6 +98,16 @@ protected:
   bool VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const std::string &basepath, const bool renameonly = false);
 #endif
 
+  // Check the blocks of a source file at the offsets where they are expected
+  // to be found, using several threads. This is much faster than the sliding
+  // window scan below, and what it does not find narrows that scan down to
+  // the parts of the file which are not where they should be.
+  bool ScanDataFileAligned(DiskFile               *diskfile,    // [in]     The file being scanned
+                           ProgressMeter<u64>     &progress,    // [in]
+                           Par2RepairerSourceFile *sourcefile,  // [in]     The file it should match
+                           std::vector<char>      &matched,     // [out]    One entry per block
+                           u32                    &matchcount); // [out]
+
   // Perform a sliding window scan of the DiskFile looking for blocks of data that
   // might belong to any of the source files (for which a verification packet was
   // available). If a block of data might be from more than one source file, prefer
@@ -165,6 +176,8 @@ protected:
 #ifdef _OPENMP
   static u32 filethreads;      // Number of threads for file processing
 #endif
+  // How many files are being scanned block by block at this moment
+  static std::atomic<u32> activeblockscans;
 
   bool                      skipdata;                // Should we skip data whilst scanning
   u64                       skipleaway;              // The leaway +/- we should allow whilst scanning

--- a/tests/test45
+++ b/tests/test45
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+execdir="$PWD"
+
+if [ -n "${PARVALGRINDOPTS+set}" ]
+then
+    PARBINARY="valgrind $PARVALGRINDOPTS $execdir/par2"
+elif [ "`which wine`" != "" ] && [ -f "$execdir/par2.exe" ]
+then
+    PARBINARY="wine $execdir/par2.exe"
+else
+    PARBINARY="$execdir/par2"
+fi
+
+if [ -z "$srcdir" ] || [ "." = "$srcdir" ]; then
+  srcdir="$PWD"
+  TESTDATA="$srcdir/tests"
+else
+  srcdir="$PWD/$srcdir"
+  TESTDATA="$srcdir/tests"
+fi
+
+TESTROOT="$PWD"
+
+testname=$(basename $0)
+rm -f "$testname.log"
+rm -rf "run$testname"
+
+mkdir "run$testname" && cd "run$testname" || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
+
+banner="Scanning the blocks of a file in parallel finds the same data"
+dashes=`echo "$banner" | sed s/./-/g`
+
+echo $dashes
+echo $banner
+echo $dashes
+
+# The -T option only exists when built with thread support
+if ! $PARBINARY -h 2>&1 | grep -q '^  -T<n>'; then
+    echo "Skipping: par2 was built without thread support."
+    cd "$TESTROOT"
+    rm -rf "run$testname"
+    exit 77
+fi
+
+# Build a data file of 64 blocks of 1024 bytes
+i=0
+while [ $i -lt 1024 ]; do
+    printf '%064d' $i
+    i=$((i + 1))
+done > data.bin
+
+$PARBINARY c -q -s1024 -c20 test.par2 data.bin || { echo "ERROR: Could not create PAR2 files" ; exit 1; } >&2
+
+cp data.bin data.bin.orig
+
+# A gap holding nothing: block 3 is corrupt
+printf 'XXXXXXXXXXXXXXXX' | dd of=data.bin bs=1 seek=3072 conv=notrunc 2>/dev/null
+
+# A gap holding data: shift blocks 10 to 19 forward by half a block, so that
+# they are still in the file but not where they are expected. Searching this
+# gap has to find them; only counting the blocks which were where they belong
+# would miss them.
+dd if=data.bin of=region.bin bs=512 skip=20 count=21 2>/dev/null
+dd if=region.bin of=data.bin bs=512 seek=21 conv=notrunc 2>/dev/null
+
+# -T2 is the default and searches the whole file a byte at a time.
+# -T4 checks each block where it is expected first, and only searches
+# what that does not account for. Both must find the same data.
+$PARBINARY v -T2 test.par2 > sequential.out 2>&1
+sequential=$?
+$PARBINARY v -T4 test.par2 > parallel.out 2>&1
+parallel=$?
+
+if [ $sequential -ne $parallel ]
+then
+    echo "ERROR: Exit code differed: -T2 gave $sequential and -T4 gave $parallel" >&2
+    exit 1
+fi
+
+# Strip the progress indicator, which is rewritten in place with \r
+tr '\r' '\n' < sequential.out | grep "data blocks" > sequential.blocks
+tr '\r' '\n' < parallel.out | grep "data blocks" > parallel.blocks
+
+if ! diff sequential.blocks parallel.blocks
+then
+    echo "ERROR: Scanning the blocks in parallel found different data" >&2
+    exit 1
+fi
+
+grep -q "Found 62 of 64 data blocks" parallel.blocks || { echo "ERROR: Expected 62 of 64 blocks to be found" ; cat parallel.blocks ; exit 1; } >&2
+
+# The repair must still work when the blocks were scanned in parallel
+$PARBINARY r -q -T4 test.par2 || { echo "ERROR: Repair failed" ; exit 1; } >&2
+
+cmp data.bin data.bin.orig || { echo "ERROR: Repaired file does not match the original" ; exit 1; } >&2
+
+cd "$TESTROOT"
+rm -rf "run$testname"
+
+exit 0

--- a/tests/test45.ps1
+++ b/tests/test45.ps1
@@ -1,0 +1,96 @@
+#!/usr/bin/env pwsh
+# Test 45: Scanning the blocks of a file in parallel finds the same data
+
+$ErrorActionPreference = "Stop"
+
+# Source common test functions
+. (Join-Path $PSScriptRoot "testfuncs.ps1")
+
+$testname = [System.IO.Path]::GetFileNameWithoutExtension($MyInvocation.MyCommand.Name)
+
+try {
+    Initialize-Test -TestName $testname
+
+    Write-Banner "Scanning the blocks of a file in parallel finds the same data"
+
+    # The -T option only exists when built with thread support
+    $help = Invoke-Par2 -Arguments @("-h") -ReturnObject
+    if ($help.StdOut -notmatch "(?m)^  -T<n>") {
+        Write-Host "Skipping: par2 was built without thread support."
+        Complete-Test
+        exit 77
+    }
+
+    # Build a data file of 64 blocks of 1024 bytes
+    $builder = New-Object System.Text.StringBuilder
+    for ($i = 0; $i -lt 1024; $i++) {
+        [void]$builder.Append($i.ToString("D64"))
+    }
+    [System.IO.File]::WriteAllText((Join-Path $PWD "data.bin"), $builder.ToString())
+
+    $create = Invoke-Par2 -Arguments @("c", "-q", "-s1024", "-c20", "test.par2", "data.bin") -ReturnObject
+    if ($create.ExitCode -ne 0) {
+        Exit-TestWithError "Could not create PAR2 files"
+    }
+
+    Copy-Item "data.bin" "data.bin.orig"
+
+    $bytes = [System.IO.File]::ReadAllBytes((Join-Path $PWD "data.bin"))
+
+    # A gap holding nothing: block 3 is corrupt
+    for ($i = 0; $i -lt 16; $i++) {
+        $bytes[3072 + $i] = [byte][char]'X'
+    }
+
+    # A gap holding data: shift blocks 10 to 19 forward by half a block, so that
+    # they are still in the file but not where they are expected. Searching this
+    # gap has to find them; only counting the blocks which were where they belong
+    # would miss them.
+    $region = New-Object byte[] 10752
+    [System.Array]::Copy($bytes, 10240, $region, 0, 10752)
+    [System.Array]::Copy($region, 0, $bytes, 10752, 10752)
+
+    [System.IO.File]::WriteAllBytes((Join-Path $PWD "data.bin"), $bytes)
+
+    # -T2 is the default and searches the whole file a byte at a time.
+    # -T4 checks each block where it is expected first, and only searches
+    # what that does not account for. Both must find the same data.
+    $sequential = Invoke-Par2 -Arguments @("v", "-T2", "test.par2") -ReturnObject
+    $parallel = Invoke-Par2 -Arguments @("v", "-T4", "test.par2") -ReturnObject
+
+    if ($sequential.ExitCode -ne $parallel.ExitCode) {
+        Exit-TestWithError "Exit code differed: -T2 gave $($sequential.ExitCode) and -T4 gave $($parallel.ExitCode)"
+    }
+
+    # Strip the progress indicator, which is rewritten in place with `r
+    $sequentialBlocks = ($sequential.StdOut -replace "`r", "`n") -split "`n" | Where-Object { $_ -match "data blocks" }
+    $parallelBlocks = ($parallel.StdOut -replace "`r", "`n") -split "`n" | Where-Object { $_ -match "data blocks" }
+
+    if (($sequentialBlocks -join "`n") -ne ($parallelBlocks -join "`n")) {
+        Write-Host "-T2:"; $sequentialBlocks | ForEach-Object { Write-Host "  $_" }
+        Write-Host "-T4:"; $parallelBlocks | ForEach-Object { Write-Host "  $_" }
+        Exit-TestWithError "Scanning the blocks in parallel found different data"
+    }
+
+    if (($parallelBlocks -join "`n") -notmatch "Found 62 of 64 data blocks") {
+        Exit-TestWithError "Expected 62 of 64 blocks to be found"
+    }
+
+    # The repair must still work when the blocks were scanned in parallel
+    $repair = Invoke-Par2 -Arguments @("r", "-q", "-T4", "test.par2") -ReturnObject
+    if ($repair.ExitCode -ne 0) {
+        Exit-TestWithError "Repair failed"
+    }
+
+    if (-not (Compare-Files -File1 "data.bin" -File2 "data.bin.orig")) {
+        Exit-TestWithError "Repaired file does not match the original"
+    }
+
+    Complete-Test
+    exit 0
+}
+catch {
+    Write-Host "ERROR: $_" -ForegroundColor Red
+    Complete-Test
+    exit 1
+}


### PR DESCRIPTION
Verification only ran files in parallel, so one large file got one thread however many were free, and a set with one big file and a few small ones left the big one running alone at the end.

This builds directly on #303. A whole file MD5 has to be fed its bytes in order from the start, in one stream, so while verification still had to produce that hash there was no way to gain from checking blocks in parallel: either the file needed a second sequential pass, or one thread had to hash it end to end while the others worked, which caps everything at single stream MD5 speed. Dropping that hash removed the sequential bottleneck, and makes this change possible.

Each block is now checked at the offset it is expected to be at, which confirms an undamaged file without searching it, and on a damaged one narrows the byte-at-a-time search down to the runs of blocks that are not where they belong. The threads come out of the existing `-T` budget rather than being extra, and go to whichever files are still being scanned, so a big file picks up the spare threads as the small ones finish.

Two supporting changes. `DiskFile::Read` now takes the position to read from as a parameter, using `pread`, or `ReadFile` with an `OVERLAPPED` offset on Windows, so that several threads can read one file at once. `pread` is required as a result, rather than falling back to seeking the handle[^1]. Each chunk is also handed to `posix_fadvise` or `F_RDADVISE` before the threads reach it.[^2]

There is one further fix, to the progress indicator: it froze part way through a scan whenever the byte count stepped past a block boundary instead of landing exactly on it.[^3]

| 768 MB on an SSD | before | after |
|---|---|---|
| one file | 3.63 s | 1.90 s |
| one file plus six small ones | 3.69 s | 2.35 s |

Raising `-T` scales further: the single file drops to 0.55 s at `-T8`.

## Spinning disks

Reading one file from several threads is the obvious risk, so I measured it on a 4 GB file with the cache dropped before every run:

| | 1 thread | 8 threads | 8 threads and prefetch |
|---|---|---|---|
| Linux, SATA | 32.5 s | 33.0 s | 32.9 s |
| Windows, USB | 30.7 s | 30.6 s | n/a |
| macOS, same USB disk | 31.9 s | 54.2 s | 31.2 s |

Linux and Windows read at the disk's sequential speed whatever the thread count. macOS was the exception, losing about 40% of its throughput, and that is what the prefetch is for: it puts macOS back to the single stream time. Windows and macOS were measured on the same physical drive, so the operating system was the only variable.

The default settings were measured separately on the same disk, since that is what most people will run. On macOS the default takes 47.6 s without the prefetch and 30.0 s with it, against 30.0 s for a single thread, so the default costs a spinning disk nothing.

Additionally users on HDD passing high -T<n> are already asking the hardware to do what it's not great at. But at default file thread count I don't believe it will make a noticeable impact.

## What it costs

The bad case is a file whose contents have shifted while its length stayed the same. Nothing is where it belongs, so the first pass is wasted and it takes about 8% longer. Insertions and deletions change the length, which is checked first, so those skip the block scan entirely. `-T1` gives back the old single stream behaviour.

I think such a situation is extremely unlikely.

## Testing

`make check` and `make distcheck` pass, and CI is green on Linux, macOS, FreeBSD, MinGW and Windows. Verification output was compared against the sequential scan for intact files, damage at the start, middle and end of a file, several separate and alternating damaged regions, insertions, truncation, renamed and extra files, and `-N` data skipping, and is the same in every case. Repairs reproduce the original byte for byte, and `tests/test45` covers the new search.

[^1]: I did consider a fallback for system without pread, but it just adds complexity for something that has been around 25+ years and anything CI is building for supports it
[^2]: I only saw any impact on macOS but I don't think it hurts at all to do it
[^3]: Note also that this will conflict with #302, which makes the same progress fix in a function this branch restructures

@animetosho sorry this is probably the most challenging to merge into turbo

I think I have at least two more improvements to send; parallel packet verification (also benefits from pread), and in-place repairs. Then look at improvements to make it nicer to use as a library.