### PR TITLE
add follow symlinks flag to create par2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -181,6 +181,7 @@ EXTRA_DIST = \
 	tests/test44 \
 	tests/test45 \
 	tests/test45.ps1 \
+	tests/test46 \
 	tests/unit_tests \
 	tests/unit_tests.ps1
 
@@ -266,6 +267,7 @@ TESTS = \
 	tests/test43 \
 	tests/test44 \
 	tests/test45 \
+	tests/test46 \
 	tests/utf8_test \
 	tests/unit_tests
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ The command line parameters for par2cmdline are as follow:
     -p       : Purge backup files and par files on successful recovery or
                when no recovery is needed
     -R       : Recurse into subdirectories (only useful on create)
+    -L       : Follow symlinks to files when scanning for source files
+               (create only, POSIX only, use at your own risk)
     -N       : data skipping (find badly mispositioned data blocks)
     -S<n>    : Skip leaway (distance +/- from expected block position)
     -B<path> : Set the basepath to use as reference for the datafiles

--- a/man/par2.1
+++ b/man/par2.1
@@ -116,6 +116,11 @@ Uniform recovery file sizes (default is variable sizes)
 .B \-R
 Recurse into subdirectories (only useful on create)
 .TP
+.B \-L
+Follow symlinks to files when scanning for source files (create only).
+Use at your own risk: symlink targets may lie outside the basepath.
+Symlinks to directories are not followed. POSIX systems only.
+.TP
 .B @
 Process a listing of files specified in text (file) input
 .SH EXITCODES

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -68,6 +68,7 @@ CommandLine::CommandLine(void)
 , redundancysize(0)
 , redundancyset(false)
 , recursive(false)
+, followlinks(false)
 {
 }
 
@@ -143,6 +144,10 @@ void CommandLine::usage(void)
     "  -n<n>    : Number of recovery files (max 31) (don't use both -n and -l)\n"
     "  -R       : Recurse into subdirectories\n"
     "             (Be aware of wildcard shell expansion)\n"
+    "  -L       : Follow symlinks to files when scanning for source files\n"
+    "             (Use at your own risk: symlink targets may lie outside the\n"
+    "             basepath. Symlinks to directories are not followed.\n"
+    "             POSIX systems only)\n"
     "   @       : Process a listing of files specified in text (file) input \n"
     "             (eg. @filelist.txt, or bare @ to read from stdin) \n"
     "\n";
@@ -788,6 +793,20 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
           }
           break;
 
+        case 'L':
+          {
+            if (operation == opCreate)
+            {
+              followlinks = true;
+            }
+            else
+            {
+              std::cerr << "Cannot specify -L (follow symlinks) unless creating." << std::endl;
+              return false;
+            }
+          }
+          break;
+
         case 'N':
           {
             if (operation == opCreate)
@@ -902,7 +921,7 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
           std::string lpath, lname;
           DiskFile::SplitFilename(line, lpath, lname);
           std::unique_ptr< std::list<std::string> > filenames(
-            DiskFile::FindFiles(lpath, lname, recursive)
+            DiskFile::FindFiles(lpath, lname, recursive, followlinks)
           );
 
           if (filenames)
@@ -932,7 +951,7 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
         std::string name;
         DiskFile::SplitFilename(argv[0], path, name);
         std::unique_ptr< std::list<std::string> > filenames(
-          DiskFile::FindFiles(path, name, recursive)
+          DiskFile::FindFiles(path, name, recursive, followlinks)
         );
 
         if (filenames)

--- a/src/commandline.h
+++ b/src/commandline.h
@@ -96,6 +96,7 @@ public:
   bool                                GetPurgeFiles(void) const  {return purgefiles;}
   bool                                GetRenameOnly(void) const  {return renameonly;}
   bool                                GetRecursive(void) const   {return recursive;}
+  bool                                GetFollowLinks(void) const {return followlinks;}
   bool                                GetSkipData(void) const    {return skipdata;}
   u64                                 GetSkipLeaway(void) const  {return skipleaway;}
 #ifdef _OPENMP
@@ -206,6 +207,7 @@ protected:
   bool redundancyset;          // Set if the redundancy has been specified
 
   bool recursive;              // recurse into subdirectories
+  bool followlinks;            // follow symlinks to files when scanning for source files
 
 };
 

--- a/src/commandline_test.cpp
+++ b/src/commandline_test.cpp
@@ -21,6 +21,9 @@
 #include <iostream>
 #include <fstream>
 #include <stdlib.h>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 #include "commandline.h"
 
@@ -1757,6 +1760,90 @@ int test12() {
 }
 
 
+#ifndef _WIN32
+int test13_helper(const char *arg, const std::vector<std::string> &extrafiles)
+{
+  // copy args into argc/argv format
+  // buffer holds copy of arg, with ' ' replaced by '\0'
+  const int len = strlen(arg);
+  int argc = 0;
+  char *buffer = new char[len+1];
+  const char **argv = new const char*[len];
+  argv[argc]=&(buffer[0]);
+  argc++;
+  for (int i = 0; i < len; i++) {
+    buffer[i] = arg[i];
+    if (buffer[i] == ' ') {
+      buffer[i] = '\0';
+      argv[argc] = &(buffer[i+1]);
+      argc++;
+    }
+  }
+  buffer[len] = '\0';
+
+  CommandLine commandline;
+  if (!commandline.Parse(argc, argv)) {
+    std::cout << "CommandLine said it was unable to parse \"" << arg << "\"" << std::endl;
+    return 1;
+  }
+
+  if (!commandline.GetFollowLinks()) {
+    std::cout << "test13 fail followlinks  arg=" << arg << std::endl;
+    return 1;
+  }
+
+  if (commandline.GetExtraFiles() != extrafiles) {
+    std::cout << "test13 fail extrafiles  arg=" << arg << std::endl;
+    return 1;
+  }
+
+  delete [] buffer;
+  delete [] argv;
+
+  return 0;
+}
+#endif
+
+
+// test the "-L" (follow symlinks) option
+int test13() {
+#ifndef _WIN32
+  // create an input file and a symlink to it.
+  std::ofstream input1;
+  input1.open("test13_input1.txt");
+  input1 << "commandline_test test13 input1.txt\n";
+  input1.close();
+  remove("test13_link1.txt");
+  if (0 != symlink("test13_input1.txt", "test13_link1.txt")) {
+    std::cout << "Could not create symlink test13_link1.txt" << std::endl;
+    return 1;
+  }
+
+  // -L is only allowed when creating.
+  if (test9_helper("par2 repair -L foo.par2 test13_link1.txt"))
+    return 1;
+  if (test9_helper("par2 verify -L foo.par2 test13_link1.txt"))
+    return 1;
+
+  // without -L, a symlink is not accepted as a source file
+  // (so create fails because there are no source files).
+  if (test9_helper("par2 create foo.par2 test13_link1.txt"))
+    return 1;
+
+  // with -L, a symlink to a file is accepted as a source file.
+  std::vector<std::string> extrafiles;
+  extrafiles.push_back(DiskFile::GetCanonicalPathname("test13_link1.txt"));
+  if (test13_helper("par2 create -L foo.par2 test13_link1.txt", extrafiles))
+    return 1;
+
+  // delete files that were created at start of test.
+  remove("test13_input1.txt");
+  remove("test13_link1.txt");
+#endif
+  return 0;
+}
+
+
 int main() {
   std::cout << "Tests 1 through 4 were moved to libpar2_test." << std::endl;
 
@@ -1792,6 +1879,10 @@ int main() {
   }
   if (test12()) {
     std::cerr << "FAILED: test12" << std::endl;
+    return 1;
+  }
+  if (test13()) {
+    std::cerr << "FAILED: test13" << std::endl;
     return 1;
   }
 

--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -372,7 +372,7 @@ std::string DiskFile::GetCanonicalPathname(std::string filename)
   return utf8::WideToUtf8(wfullname.get());
 }
 
-std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, std::string wildcard, bool recursive)
+std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, std::string wildcard, bool recursive, bool followlinks)
 {
   // check path, if not ending with path separator, add one
   char pathend = *path.rbegin();
@@ -401,7 +401,7 @@ std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, 
 
         std::string nwwildcard="*";
 	std::unique_ptr< std::list<std::string> > dirmatches(
-						 DiskFile::FindFiles(path + utf8::WideToUtf8(fd.cFileName), nwwildcard, true)
+						 DiskFile::FindFiles(path + utf8::WideToUtf8(fd.cFileName), nwwildcard, true, followlinks)
 						 );
 
         // append without requiring ordering
@@ -807,7 +807,7 @@ std::string DiskFile::GetCanonicalPathname(std::string filename)
   return result;
 }
 
-std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, std::string wildcard, bool recursive)
+std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, std::string wildcard, bool recursive, bool followlinks)
 {
   // check path, if not ending with path separator, add one
   char pathend = *path.rbegin();
@@ -853,13 +853,21 @@ std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, 
 
                 std::string nwwildcard="*";
                 std::unique_ptr< std::list<std::string> > dirmatches(
-							 DiskFile::FindFiles(fn, nwwildcard, true)
+							 DiskFile::FindFiles(fn, nwwildcard, true, followlinks)
 							 );
                 matches->splice(matches->end(), *dirmatches);
               }
               else if (S_ISREG(st.st_mode))
               {
                 matches->push_back(path + name);
+              }
+              else if (followlinks && S_ISLNK(st.st_mode))
+              {
+                struct stat stt;
+                if (stat(fn.c_str(), &stt) == 0 && S_ISREG(stt.st_mode))
+                {
+                  matches->push_back(path + name);
+                }
               }
             }
           }
@@ -890,7 +898,7 @@ std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, 
 
                   std::string nwwildcard="*";
 		  std::unique_ptr< std::list<std::string> > dirmatches(
-							   DiskFile::FindFiles(fn, nwwildcard, true)
+							   DiskFile::FindFiles(fn, nwwildcard, true, followlinks)
 							   );
 
                   matches->splice(matches->end(), *dirmatches);
@@ -898,6 +906,14 @@ std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, 
                 else if (S_ISREG(st.st_mode))
                 {
                   matches->push_back(path + name);
+                }
+                else if (followlinks && S_ISLNK(st.st_mode))
+                {
+                  struct stat stt;
+                  if (stat(fn.c_str(), &stt) == 0 && S_ISREG(stt.st_mode))
+                  {
+                    matches->push_back(path + name);
+                  }
                 }
               }
             }
@@ -919,7 +935,7 @@ std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, 
       {
         std::string nwwildcard="*";
 	std::unique_ptr< std::list<std::string> > dirmatches(
-						 DiskFile::FindFiles(fn, nwwildcard, true)
+						 DiskFile::FindFiles(fn, nwwildcard, true, followlinks)
 						 );
 
         matches->splice(matches->end(), *dirmatches);
@@ -927,6 +943,14 @@ std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, 
       else if (S_ISREG(st.st_mode))
       {
         matches->push_back(path + wildcard);
+      }
+      else if (followlinks && S_ISLNK(st.st_mode))
+      {
+        struct stat stt;
+        if (stat(fn.c_str(), &stt) == 0 && S_ISREG(stt.st_mode))
+        {
+          matches->push_back(path + wildcard);
+        }
       }
     }
   }

--- a/src/diskfile.h
+++ b/src/diskfile.h
@@ -116,7 +116,7 @@ public:
 
   // Search the specified path for files which match the specified wildcard
   // and return their names in a list.
-  static std::unique_ptr< std::list<std::string> > FindFiles(std::string path, std::string wildcard, bool recursive);
+  static std::unique_ptr< std::list<std::string> > FindFiles(std::string path, std::string wildcard, bool recursive, bool followlinks = false);
 
 protected:
   // NOTE: These are pointers so that the operator= works correctly.

--- a/src/diskfile_test.cpp
+++ b/src/diskfile_test.cpp
@@ -20,6 +20,9 @@
 #include <iostream>
 #include <fstream>
 #include <memory>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 #include "libpar2internal.h"
 
@@ -736,6 +739,53 @@ int test6() {
 }
 
 
+// test symlink handling in FindFiles
+int test7() {
+#ifndef _WIN32
+  std::ofstream input1;
+  input1.open("input1.txt", std::ofstream::out | std::ofstream::binary);
+  const char *input1_contents = "diskfile_test test7 input1.txt";
+  input1 << input1_contents;
+  input1.close();
+
+  if (0 != symlink("input1.txt", "input1_link.txt")) {
+    std::cout << "Could not create symlink input1_link.txt" << std::endl;
+    return 1;
+  }
+  if (0 != symlink("not_there", "dangling_link.txt")) {
+    std::cout << "Could not create symlink dangling_link.txt" << std::endl;
+    return 1;
+  }
+
+  // by default (followlinks=false) symlinks are not returned
+  std::unique_ptr< std::list<std::string> > files = DiskFile::FindFiles(".", "input1_link.txt", false);
+  if (files->size() != 0) {
+    std::cout << "FindFiles returned symlink when followlinks=false" << std::endl;
+    return 1;
+  }
+
+  // with followlinks=true a symlink to a file is returned
+  files = DiskFile::FindFiles(".", "input1_link.txt", false, true);
+  if (files->size() != 1 || *(files->begin()) != "." + fs + "input1_link.txt") {
+    std::cout << "FindFiles failed to return followed symlink" << std::endl;
+    return 1;
+  }
+
+  // dangling symlinks are never returned
+  files = DiskFile::FindFiles(".", "dangling_link.txt", false, true);
+  if (files->size() != 0) {
+    std::cout << "FindFiles returned dangling symlink" << std::endl;
+    return 1;
+  }
+
+  remove("input1.txt");
+  remove("input1_link.txt");
+  remove("dangling_link.txt");
+#endif
+  return 0;
+}
+
+
 int main() {
   if (test1()) {
     std::cerr << "FAILED: test1" << std::endl;
@@ -759,6 +809,10 @@ int main() {
   }
   if (test6()) {
     std::cerr << "FAILED: test6" << std::endl;
+    return 1;
+  }
+  if (test7()) {
+    std::cerr << "FAILED: test7" << std::endl;
     return 1;
   }
 

--- a/tests/test46
+++ b/tests/test46
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+execdir="$PWD"
+
+# valgrind tests memory usage.
+# wine allow for windows testing on linux
+if [ -n "${PARVALGRINDOPTS+set}" ]
+then
+    PARBINARY="valgrind $PARVALGRINDOPTS $execdir/par2"
+elif [ "`which wine`" != "" ] && [ -f "$execdir/par2.exe" ]
+then
+    PARBINARY="wine $execdir/par2.exe"
+else
+    PARBINARY="$execdir/par2"
+fi
+
+
+if [ -z "$srcdir" ] || [ "." = "$srcdir" ]; then
+  srcdir="$PWD"
+  TESTDATA="$srcdir/tests"
+else
+  srcdir="$PWD/$srcdir"
+  TESTDATA="$srcdir/tests"
+fi
+
+TESTROOT="$PWD"
+
+testname=$(basename $0)
+rm -f "$testname.log"
+rm -rf "run$testname"
+
+mkdir "run$testname" && cd "run$testname" || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
+
+banner="Verify -L (follow symlinks) handling"
+dashes=`echo "$banner" | sed s/./-/g`
+
+echo $dashes
+echo $banner
+echo $dashes
+
+# generate test data and links
+echo -n '01234567890abcdef' > test_file
+ln -s test_file test_link
+mkdir test_dir
+ln -s $(pwd)/test_file test_dir/test_link
+ln -s test_dir dir_link
+ln -s NOT_EXISTING dead_link
+
+# without -L, links are not followed for non-primary files
+$PARBINARY c -r10 nofollow test_link && { echo "ERROR: followed link without -L" ; exit 1; } >&2
+
+# test creation with symlink following
+echo "*** Create with -L ***"
+$PARBINARY c -L -r10 follow_links test_link || { echo "ERROR: creating with -L failed" ; exit 1; } >&2
+
+# the linked data verifies and repairs
+echo "*** Verify good file link ***"
+$PARBINARY v -q follow_links || { echo "ERROR: verifying good link data failed" ; exit 1; } >&2
+cp test_file test_file.bak
+echo -n "!" >> test_file
+echo "*** Verify damaged file link ***"
+$PARBINARY v -q follow_links && { echo "ERROR: verifying damaged link data succeeded" ; exit 1; } >&2
+echo "*** Repair ***"
+$PARBINARY r -q follow_links || { echo "ERROR: repairing linked data failed" ; exit 1; } >&2
+diff test_link test_file.bak || { echo "ERROR: comparison after repairing linked data failed" ; exit 1; } >&2
+
+# with -R -L, links to files inside directories are followed
+echo "*** Create recursive with -L ***"
+$PARBINARY c -R -L -r10 dirrec test_dir || { echo "ERROR: recursive create with -L failed" ; exit 1; } >&2
+$PARBINARY v -q dirrec || { echo "ERROR: verifying recursive link data failed" ; exit 1; } >&2
+
+# linked directories are not followed, even with -R -L
+$PARBINARY c -R -L -r10 dirlink dir_link && { echo "ERROR: followed linked directory" ; exit 1; } >&2
+
+# dead links fail, even with -L
+$PARBINARY c -L -r10 dead dead_link && { echo "ERROR: calculating dead link data succeeded" ; exit 1; } >&2
+
+echo "\nLink tests succeeded!"
+
+cd "$TESTROOT"
+rm -rf "run$testname"
+
+exit 0


### PR DESCRIPTION
When you are aware of what you are doing, on POSIX systems you can now pass -L to follow symlinks. This remains a risky operation if you link to the wrong files and then later repair them.

Closes: #289