### PR TITLE
Scan each file with a reader thread feeding worker threads

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -182,6 +182,8 @@ EXTRA_DIST = \
 	tests/test45 \
 	tests/test45.ps1 \
 	tests/test46 \
+	tests/test47 \
+	tests/test47.ps1 \
 	tests/unit_tests \
 	tests/unit_tests.ps1
 
@@ -268,6 +270,7 @@ TESTS = \
 	tests/test44 \
 	tests/test45 \
 	tests/test46 \
+	tests/test47 \
 	tests/utf8_test \
 	tests/unit_tests
 

--- a/config.h.in
+++ b/config.h.in
@@ -34,9 +34,6 @@
 /* Define to 1 if you have the <ndir.h> header file, and it defines 'DIR'. */
 #undef HAVE_NDIR_H
 
-/* Define to 1 if you have the 'posix_fadvise' function. */
-#undef HAVE_POSIX_FADVISE
-
 /* Define to 1 if you have the 'pread' function. */
 #undef HAVE_PREAD
 

--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,6 @@ AC_FUNC_MEMCMP
 AC_CHECK_FUNCS([stricmp] [strcasecmp])
 AC_CHECK_FUNCS([strchr] [memcpy])
 AC_CHECK_FUNCS([pread])
-AC_CHECK_FUNCS([posix_fadvise])
 
 dnl DiskFile::Read is given the position to read from, using ReadFile with an
 dnl OVERLAPPED offset on Windows and pread everywhere else. Without one of the

--- a/man/par2.1
+++ b/man/par2.1
@@ -62,12 +62,7 @@ Memory (in MB) to use (default is half of total physical memory)
 .RB "Number of threads used for main processing (default auto-detected)"
 .TP
 .B \-T<n>
-.RB "Number of files hashed in parallel (default 2)."
-Threads which are not busy with another file also share out the blocks of a
-single file, so that one large file is not left to a single thread while the
-others have finished. No more threads are used in total than this option asks
-for. Each block is checked where it is expected to be, and only the parts of a
-file whose blocks are not there are searched a byte at a time afterwards
+.RB "Number of files hashed in parallel (default 2)"
 .TP
 .B \-\-
 Treat all following arguments as filenames

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -119,9 +119,8 @@ void CommandLine::usage(void)
 #ifdef _OPENMP
   std::cout <<
     "  -t<n>    : Number of threads used for main processing (" << omp_get_max_threads() << " detected)\n"
-    "  -T<n>    : Number of files hashed in parallel (" << _FILE_THREADS << " are the default)\n"
-    "             Threads not busy with another file share out the blocks of a\n"
-    "             single file, so that one large file is not left to a single thread\n";
+    "  -T<n>    : Number of files hashed in parallel\n"
+    "             (" << _FILE_THREADS << " are the default)\n";
 #endif
   std::cout <<
     "  --       : Treat all following arguments as filenames\n"

--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -273,12 +273,6 @@ bool DiskFile::Open(const std::string &_filename, u64 _filesize)
   return true;
 }
 
-// Ask the system to begin reading a range of the file into its cache
-
-void DiskFile::Prefetch(u64, u64)
-{
-}
-
 // Read some data from disk
 
 bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxlength)
@@ -652,36 +646,6 @@ bool DiskFile::Open(const std::string &_filename, u64 _filesize)
   exists = true;
 
   return true;
-}
-
-// Ask the system to begin reading a range of the file into its cache
-
-void DiskFile::Prefetch(u64 _offset, u64 _length)
-{
-  assert(file != 0);
-
-  if (_length == 0)
-    return;
-
-#if defined(HAVE_POSIX_FADVISE)
-  posix_fadvise(fileno(file), (OffsetType)_offset, (OffsetType)_length, POSIX_FADV_WILLNEED);
-#elif defined(F_RDADVISE)
-  // The count is only an int, so a longer range has to be asked for in pieces
-  while (_length > 0)
-  {
-    struct radvisory ra;
-    ra.ra_offset = (OffsetType)_offset;
-    ra.ra_count = (int)std::min(_length, (u64)1 << 30);
-
-    if (fcntl(fileno(file), F_RDADVISE, &ra) == -1)
-      break;
-
-    _offset += (u64)ra.ra_count;
-    _length -= (u64)ra.ra_count;
-  }
-#else
-  (void)_offset;
-#endif
 }
 
 // Read some data from disk

--- a/src/diskfile.h
+++ b/src/diskfile.h
@@ -76,10 +76,6 @@ public:
   bool Read(u64 offset, void *buffer, size_t length,
 	    LengthType maxlength = MAX_LENGTH);
 
-  // Ask the system to begin reading a range of the file into its cache. This
-  // is only a hint and does nothing on a system which cannot be told.
-  void Prefetch(u64 offset, u64 length);
-
   // Close the file
   void Close(void);
 

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -1642,16 +1642,16 @@ bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [i
 
   readbatch(0, buffer[0]);
 
-  for (u32 firstblock=0; firstblock<blockcount && !readfailed; firstblock+=batchblocks)
+  #pragma omp parallel num_threads(workers)
   {
-    const u32 lastblock = std::min(firstblock + batchblocks, blockcount);
-    const u32 batch = firstblock / batchblocks;
-
-    std::vector<char> &checking = buffer[batch % 2];
-    std::vector<char> &reading = buffer[(batch + 1) % 2];
-
-    #pragma omp parallel num_threads(workers)
+    for (u32 firstblock=0; firstblock<blockcount && !readfailed; firstblock+=batchblocks)
     {
+      const u32 lastblock = std::min(firstblock + batchblocks, blockcount);
+      const u32 batch = firstblock / batchblocks;
+
+      std::vector<char> &checking = buffer[batch % 2];
+      std::vector<char> &reading = buffer[(batch + 1) % 2];
+
       // Reads the next block while this one is being hashed
       #pragma omp single nowait
       {

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -35,11 +35,19 @@ static char THIS_FILE[]=__FILE__;
 #endif
 
 
-// static variable
 #ifdef _OPENMP
 u32 Par2Repairer::filethreads = _FILE_THREADS;
+u32 Par2Repairer::blockthreads = 1;
+
+void Par2Repairer::SetBlockThreads(size_t filecount)
+{
+  u32 files = std::max(1u, filethreads);
+  if (filecount > 0 && filecount < files)
+    files = (u32)filecount;
+
+  blockthreads = std::max(1u, (u32)omp_get_max_threads() / files);
+}
 #endif
-std::atomic<u32> Par2Repairer::activeblockscans(0);
 
 
 // Test whether filename has a .par2 / .PAR2 / .Par2 extension.
@@ -1233,6 +1241,10 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
   ProgressMeter<u64> progress(sout, "Scanning: ", mttotalsize);
 #endif
 
+#ifdef _OPENMP
+  SetBlockThreads(sortedfiles.size());
+#endif
+
   // Start verifying the files
   #pragma omp parallel for schedule(dynamic) num_threads(Par2Repairer::GetFileThreads())
   for (int i=0; i< static_cast<int>(sortedfiles.size()); ++i)
@@ -1343,6 +1355,10 @@ bool Par2Repairer::VerifyExtraFiles(const std::vector<std::string> &extrafiles, 
       mttotalextrasize += DiskFile::GetFileSize(extrafiles[i]);
 
     ProgressMeter<u64> progress(sout, "Scanning: ", mttotalextrasize);
+#endif
+
+#ifdef _OPENMP
+    SetBlockThreads(extrafiles.size());
 #endif
 
     #pragma omp parallel for schedule(dynamic) num_threads(Par2Repairer::GetFileThreads())
@@ -1569,7 +1585,6 @@ bool Par2Repairer::VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *so
 }
 
 // Check every block of a source file at the offset where it is expected to be.
-// Nothing is recorded here: the caller is told which blocks were found.
 bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [in]
                                        ProgressMeter<u64>     &progress,   // [in]
                                        Par2RepairerSourceFile *sourcefile, // [in]
@@ -1601,82 +1616,82 @@ bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [i
 
   matched.assign(blockcount, 0);
 
-  // The file threads are the whole budget, so the threads not being spent on
-  // another file are shared out between the blocks of this one
 #ifdef _OPENMP
-  const u32 budget = filethreads;
+  const u32 workers = blockthreads;
 #else
-  const u32 budget = 1;
+  const u32 workers = 1;
 #endif
 
-  ++activeblockscans;
+  // One block for each thread is read at a time, into one of two buffers, so
+  // that the next batch can be read while the current one is being checked
+  const u32 batchblocks = workers;
 
-  // The file is checked a chunk of blocks at a time, so that the number of
-  // threads can be raised again each time another file finishes
-  u32 blocknumber = 0;
+  std::vector<char> buffer[2];
+  buffer[0].resize((size_t)batchblocks * blocksize);
+  buffer[1].resize((size_t)batchblocks * blocksize);
 
-  while (blocknumber < blockcount)
+  bool readfailed = false;
+
+  // Read a run of blocks in order, padding a short final block with zeroes so
+  // that it matches the verification entry recorded for it
+  auto readblock = [&](u32 firstblock, std::vector<char> &into)
   {
-    u32 scanning = activeblockscans.load();
-    if (scanning < 1)
-      scanning = 1;
+    const u32 lastblock = std::min(firstblock + batchblocks, blockcount);
 
-    u32 threads = budget / scanning;
-    if (threads < 1)
-      threads = 1;
-
-    const int first = static_cast<int>(blocknumber);
-    const int last  = static_cast<int>(std::min((u64)blockcount, (u64)blocknumber + threads * 4));
-
-    // Reading a chunk in one go keeps the disk sequential, where the threads
-    // reading their own parts of it at the same time would not
-    const u64 chunkstart = (u64)first * blocksize;
-    diskfile->Prefetch(chunkstart, std::min(filesize, (u64)last * blocksize) - chunkstart);
-
-#ifdef _OPENMP
-    #pragma omp parallel num_threads(threads)
-#endif
+    for (u32 b=firstblock; b<lastblock; ++b)
     {
-      std::vector<char> buffer((size_t)blocksize);
+      const u64 offset = (u64)b * blocksize;
+      const u64 length = std::min(blocksize, filesize - offset);
+      char *at = &into[(size_t)(b - firstblock) * blocksize];
 
-      // Every block costs the same, so each thread takes a run of consecutive
-      // blocks and its reads stay in order
-#ifdef _OPENMP
-      #pragma omp for schedule(static)
-#endif
-      for (int b=first; b<last; ++b)
+      if (!diskfile->Read(offset, at, (size_t)length))
       {
-        const u64 offset = (u64)b * blocksize;
-        const u64 length = std::min(blocksize, filesize - offset);
+        readfailed = true;
+        return;
+      }
 
-        bool blockmatched = diskfile->Read(offset, &buffer[0], (size_t)length);
+      if (length < blocksize)
+        memset(at + length, 0, (size_t)(blocksize - length));
+    }
+  };
 
-        if (blockmatched)
-        {
-          // The verification entry for the last block of a file covers the
-          // block padded out to the full block size with zeroes
-          if (length < blocksize)
-            memset(&buffer[length], 0, (size_t)(blocksize - length));
+  readblock(0, buffer[0]);
 
-          const FILEVERIFICATIONENTRY *entry = verificationpacket->VerificationEntry(b);
+  for (u32 firstblock=0; firstblock<blockcount && !readfailed; firstblock+=batchblocks)
+  {
+    const u32 lastblock = std::min(firstblock + batchblocks, blockcount);
+    const u32 batch = firstblock / batchblocks;
 
-          u32 checksum = ~0 ^ CRCUpdateBlock(~0, (size_t)blocksize, &buffer[0]);
+    std::vector<char> &checking = buffer[batch % 2];
+    std::vector<char> &reading = buffer[(batch + 1) % 2];
 
-          blockmatched = checksum == entry->crc;
+    #pragma omp parallel num_threads(workers)
+    {
+      // Reads the next block while this one is being hashed
+      #pragma omp single nowait
+      {
+        if (lastblock < blockcount)
+          readblock(lastblock, reading);
+      }
 
-          if (blockmatched)
-          {
-            MD5Context context;
-            context.Update(&buffer[0], (size_t)blocksize);
+      #pragma omp for schedule(dynamic)
+      for (int b=(int)firstblock; b<(int)lastblock; ++b)
+      {
+        const u64 length = std::min(blocksize, filesize - (u64)b * blocksize);
+        const char *at = &checking[(size_t)(b - (int)firstblock) * blocksize];
+        const FILEVERIFICATIONENTRY *entry = verificationpacket->VerificationEntry(b);
 
-            MD5Hash hash;
-            context.Final(hash);
+        const u32 checksum = ~0 ^ CRCUpdateBlock(~0, (size_t)blocksize, at);
+        if (checksum != entry->crc)
+          continue;
 
-            blockmatched = hash == entry->hash;
-          }
-        }
+        MD5Context context;
+        context.Update(at, (size_t)blocksize);
 
-        if (!blockmatched)
+        MD5Hash hash;
+        context.Final(hash);
+
+        if (!(hash == entry->hash))
           continue;
 
         matched[b] = 1;
@@ -1685,11 +1700,10 @@ bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [i
           progress.Add(length);
       }
     }
-
-    blocknumber = static_cast<u32>(last);
   }
 
-  --activeblockscans;
+  if (readfailed)
+    return false;
 
   for (u32 b=0; b<blockcount; ++b)
     if (matched[b])
@@ -2847,6 +2861,10 @@ bool Par2Repairer::VerifyTargetFiles(const std::string &basepath)
       mttotalsize += verifylist[i]->GetDescriptionPacket()->FileSize();
   }
   ProgressMeter<u64> progress(sout, "Scanning: ", mttotalsize);
+#endif
+
+#ifdef _OPENMP
+  SetBlockThreads(verifylist.size());
 #endif
 
   // Iterate through each file in the verification list

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -37,16 +37,6 @@ static char THIS_FILE[]=__FILE__;
 
 #ifdef _OPENMP
 u32 Par2Repairer::filethreads = _FILE_THREADS;
-u32 Par2Repairer::blockthreads = 1;
-
-void Par2Repairer::SetBlockThreads(size_t filecount)
-{
-  u32 files = std::max(1u, filethreads);
-  if (filecount > 0 && filecount < files)
-    files = (u32)filecount;
-
-  blockthreads = std::max(1u, (u32)omp_get_max_threads() / files);
-}
 #endif
 
 
@@ -1240,12 +1230,8 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
   ProgressMeter<u64> progress(sout, "Scanning: ", mttotalsize);
 #endif
 
-#ifdef _OPENMP
-  SetBlockThreads(sortedfiles.size());
-#endif
-
   // Start verifying the files
-  #pragma omp parallel for schedule(dynamic) num_threads(Par2Repairer::GetFileThreads())
+  #pragma omp parallel for schedule(dynamic) num_threads(Par2Repairer::FileThreads(sortedfiles.size()))
   for (int i=0; i< static_cast<int>(sortedfiles.size()); ++i)
   {
     // Do we have a source file
@@ -1356,11 +1342,7 @@ bool Par2Repairer::VerifyExtraFiles(const std::vector<std::string> &extrafiles, 
     ProgressMeter<u64> progress(sout, "Scanning: ", mttotalextrasize);
 #endif
 
-#ifdef _OPENMP
-    SetBlockThreads(extrafiles.size());
-#endif
-
-    #pragma omp parallel for schedule(dynamic) num_threads(Par2Repairer::GetFileThreads())
+    #pragma omp parallel for schedule(dynamic) num_threads(Par2Repairer::FileThreads(extrafiles.size()))
     for (int i=0; i< static_cast<int>(extrafiles.size()); ++i)
     {
       std::string filename = extrafiles[i];
@@ -1613,13 +1595,13 @@ bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [i
   if (0 == blockcount)
     return false;
 
-  matched.assign(blockcount, 0);
-
 #ifdef _OPENMP
-  const u32 workers = blockthreads;
+  const u32 workers = std::max(1u, (u32)omp_get_max_threads() / (u32)std::max(1, omp_get_num_threads()));
 #else
   const u32 workers = 1;
 #endif
+
+  matched.assign(blockcount, 0);
 
   // One block for each thread is read at a time, into one of two buffers, so
   // that the next batch can be read while the current one is being checked
@@ -2859,12 +2841,8 @@ bool Par2Repairer::VerifyTargetFiles(const std::string &basepath)
   ProgressMeter<u64> progress(sout, "Scanning: ", mttotalsize);
 #endif
 
-#ifdef _OPENMP
-  SetBlockThreads(verifylist.size());
-#endif
-
   // Iterate through each file in the verification list
-  #pragma omp parallel for schedule(dynamic) num_threads(Par2Repairer::GetFileThreads())
+  #pragma omp parallel for schedule(dynamic) num_threads(Par2Repairer::FileThreads(verifylist.size()))
   for (int i=0; i< static_cast<int>(verifylist.size()); ++i)
   {
     Par2RepairerSourceFile *sourcefile = verifylist[i];

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -1631,30 +1631,27 @@ bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [i
 
   bool readfailed = false;
 
-  // Read a run of blocks in order, padding a short final block with zeroes so
-  // that it matches the verification entry recorded for it
-  auto readblock = [&](u32 firstblock, std::vector<char> &into)
+  // The blocks of a batch are next to each other, so they are read in one go.
+  // Only the last block of a file can be short, and its entry covers it padded
+  // out to the full block size with zeroes
+  auto readbatch = [&](u32 firstblock, std::vector<char> &into)
   {
-    const u32 lastblock = std::min(firstblock + batchblocks, blockcount);
+    const u32 blocks = std::min(firstblock + batchblocks, blockcount) - firstblock;
+    const u64 offset = (u64)firstblock * blocksize;
+    const size_t span = (size_t)blocks * blocksize;
+    const size_t length = (size_t)std::min((u64)span, filesize - offset);
 
-    for (u32 b=firstblock; b<lastblock; ++b)
+    if (!diskfile->Read(offset, &into[0], length))
     {
-      const u64 offset = (u64)b * blocksize;
-      const u64 length = std::min(blocksize, filesize - offset);
-      char *at = &into[(size_t)(b - firstblock) * blocksize];
-
-      if (!diskfile->Read(offset, at, (size_t)length))
-      {
-        readfailed = true;
-        return;
-      }
-
-      if (length < blocksize)
-        memset(at + length, 0, (size_t)(blocksize - length));
+      readfailed = true;
+      return;
     }
+
+    if (length < span)
+      memset(&into[length], 0, span - length);
   };
 
-  readblock(0, buffer[0]);
+  readbatch(0, buffer[0]);
 
   for (u32 firstblock=0; firstblock<blockcount && !readfailed; firstblock+=batchblocks)
   {
@@ -1670,7 +1667,7 @@ bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [i
       #pragma omp single nowait
       {
         if (lastblock < blockcount)
-          readblock(lastblock, reading);
+          readbatch(lastblock, reading);
       }
 
       #pragma omp for schedule(dynamic)

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -172,6 +172,8 @@ Result Par2Repairer::Process(
   // so both levels need to be able to run threads.
 #if _OPENMP >= 200805
   omp_set_max_active_levels(2);
+#else
+  omp_set_nested(1);
 #endif
 #endif
 

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -160,10 +160,6 @@ Result Par2Repairer::Process(
 			     const u64 _skipleaway
 			     )
 {
-#ifdef _OPENMP
-  filethreads = _filethreads;
-#endif
-
   // Should we skip data whilst scanning files
   skipdata = _skipdata;
 
@@ -178,6 +174,9 @@ Result Par2Repairer::Process(
   // Set the number of threads
   if (nthreads != 0)
     omp_set_num_threads(nthreads);
+
+  // No more files are read at once than there are threads to hash them with
+  filethreads = std::min(_filethreads, (u32)omp_get_max_threads());
 
   // Files are scanned in parallel, and so are the blocks within one file,
   // so both levels need to be able to run threads.

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -1601,6 +1601,11 @@ bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [i
   const u32 workers = 1;
 #endif
 
+  // A single thread gains nothing from checking the blocks up front, and a
+  // damaged file would then be read a second time by the scan below
+  if (workers < 2)
+    return false;
+
   matched.assign(blockcount, 0);
 
   // One block for each thread is read at a time, into one of two buffers, so

--- a/src/par2repairer.h
+++ b/src/par2repairer.h
@@ -21,8 +21,6 @@
 #ifndef __PAR2REPAIRER_H__
 #define __PAR2REPAIRER_H__
 
-#include <atomic>
-
 class Par2Repairer
 {
 public:
@@ -102,9 +100,10 @@ protected:
 #endif
 
   // Check the blocks of a source file at the offsets where they are expected
-  // to be found, using several threads. This is much faster than the sliding
-  // window scan below, and what it does not find narrows that scan down to
-  // the parts of the file which are not where they should be.
+  // to be found. One thread reads the file in order while the others check the
+  // blocks it has read. This is much faster than the sliding window scan below,
+  // and what it does not find narrows that scan down to the parts of the file
+  // which are not where they should be.
   bool ScanDataFileAligned(DiskFile               *diskfile,    // [in]     The file being scanned
                            ProgressMeter<u64>     &progress,    // [in]
                            Par2RepairerSourceFile *sourcefile,  // [in]     The file it should match
@@ -164,6 +163,7 @@ protected:
 
 #ifdef _OPENMP
   static u32                          GetFileThreads(void) {return filethreads;}
+  static void                         SetBlockThreads(size_t filecount);
 #endif
 
 protected:
@@ -178,9 +178,8 @@ protected:
 
 #ifdef _OPENMP
   static u32 filethreads;      // Number of threads for file processing
+  static u32 blockthreads;     // Number of threads each file gets for its blocks
 #endif
-  // How many files are being scanned block by block at this moment
-  static std::atomic<u32> activeblockscans;
 
   bool                      skipdata;                // Should we skip data whilst scanning
   u64                       skipleaway;              // The leaway +/- we should allow whilst scanning

--- a/src/par2repairer.h
+++ b/src/par2repairer.h
@@ -162,8 +162,8 @@ protected:
   bool RemoveParFiles(void);
 
 #ifdef _OPENMP
-  static u32                          GetFileThreads(void) {return filethreads;}
-  static void                         SetBlockThreads(size_t filecount);
+  static u32                          FileThreads(size_t filecount)
+    {return (u32)std::max<size_t>(1, std::min<size_t>(filethreads, filecount));}
 #endif
 
 protected:
@@ -178,7 +178,6 @@ protected:
 
 #ifdef _OPENMP
   static u32 filethreads;      // Number of threads for file processing
-  static u32 blockthreads;     // Number of threads each file gets for its blocks
 #endif
 
   bool                      skipdata;                // Should we skip data whilst scanning

--- a/tests/test45
+++ b/tests/test45
@@ -35,8 +35,8 @@ echo $dashes
 echo $banner
 echo $dashes
 
-# The -T option only exists when built with thread support
-if ! $PARBINARY -h 2>&1 | grep -q '^  -T<n>'; then
+# The -t option only exists when built with thread support
+if ! $PARBINARY -h 2>&1 | grep -q '^  -t<n>'; then
     echo "Skipping: par2 was built without thread support."
     cd "$TESTROOT"
     rm -rf "run$testname"
@@ -64,17 +64,17 @@ printf 'XXXXXXXXXXXXXXXX' | dd of=data.bin bs=1 seek=3072 conv=notrunc 2>/dev/nu
 dd if=data.bin of=region.bin bs=512 skip=20 count=21 2>/dev/null
 dd if=region.bin of=data.bin bs=512 seek=21 conv=notrunc 2>/dev/null
 
-# -T2 is the default and searches the whole file a byte at a time.
-# -T4 checks each block where it is expected first, and only searches
-# what that does not account for. Both must find the same data.
-$PARBINARY v -T2 test.par2 > sequential.out 2>&1
+# A single thread leaves the whole file to the byte at a time search.
+# Several threads check each block where it is expected first, and only
+# search what that does not account for. Both must find the same data.
+$PARBINARY v -t1 test.par2 > sequential.out 2>&1
 sequential=$?
-$PARBINARY v -T4 test.par2 > parallel.out 2>&1
+$PARBINARY v -t4 test.par2 > parallel.out 2>&1
 parallel=$?
 
 if [ $sequential -ne $parallel ]
 then
-    echo "ERROR: Exit code differed: -T2 gave $sequential and -T4 gave $parallel" >&2
+    echo "ERROR: Exit code differed: -t1 gave $sequential and -t4 gave $parallel" >&2
     exit 1
 fi
 
@@ -91,7 +91,7 @@ fi
 grep -q "Found 62 of 64 data blocks" parallel.blocks || { echo "ERROR: Expected 62 of 64 blocks to be found" ; cat parallel.blocks ; exit 1; } >&2
 
 # The repair must still work when the blocks were scanned in parallel
-$PARBINARY r -q -T4 test.par2 || { echo "ERROR: Repair failed" ; exit 1; } >&2
+$PARBINARY r -q -t4 test.par2 || { echo "ERROR: Repair failed" ; exit 1; } >&2
 
 cmp data.bin data.bin.orig || { echo "ERROR: Repaired file does not match the original" ; exit 1; } >&2
 

--- a/tests/test45.ps1
+++ b/tests/test45.ps1
@@ -13,9 +13,9 @@ try {
 
     Write-Banner "Scanning the blocks of a file in parallel finds the same data"
 
-    # The -T option only exists when built with thread support
+    # The -t option only exists when built with thread support
     $help = Invoke-Par2 -Arguments @("-h") -ReturnObject
-    if ($help.StdOut -notmatch "(?m)^  -T<n>") {
+    if ($help.StdOut -notmatch "(?m)^  -t<n>") {
         Write-Host "Skipping: par2 was built without thread support."
         Complete-Test
         exit 77
@@ -52,14 +52,14 @@ try {
 
     [System.IO.File]::WriteAllBytes((Join-Path $PWD "data.bin"), $bytes)
 
-    # -T2 is the default and searches the whole file a byte at a time.
-    # -T4 checks each block where it is expected first, and only searches
-    # what that does not account for. Both must find the same data.
-    $sequential = Invoke-Par2 -Arguments @("v", "-T2", "test.par2") -ReturnObject
-    $parallel = Invoke-Par2 -Arguments @("v", "-T4", "test.par2") -ReturnObject
+    # A single thread leaves the whole file to the byte at a time search.
+    # Several threads check each block where it is expected first, and only
+    # search what that does not account for. Both must find the same data.
+    $sequential = Invoke-Par2 -Arguments @("v", "-t1", "test.par2") -ReturnObject
+    $parallel = Invoke-Par2 -Arguments @("v", "-t4", "test.par2") -ReturnObject
 
     if ($sequential.ExitCode -ne $parallel.ExitCode) {
-        Exit-TestWithError "Exit code differed: -T2 gave $($sequential.ExitCode) and -T4 gave $($parallel.ExitCode)"
+        Exit-TestWithError "Exit code differed: -t1 gave $($sequential.ExitCode) and -t4 gave $($parallel.ExitCode)"
     }
 
     # Strip the progress indicator, which is rewritten in place with `r
@@ -67,8 +67,8 @@ try {
     $parallelBlocks = ($parallel.StdOut -replace "`r", "`n") -split "`n" | Where-Object { $_ -match "data blocks" }
 
     if (($sequentialBlocks -join "`n") -ne ($parallelBlocks -join "`n")) {
-        Write-Host "-T2:"; $sequentialBlocks | ForEach-Object { Write-Host "  $_" }
-        Write-Host "-T4:"; $parallelBlocks | ForEach-Object { Write-Host "  $_" }
+        Write-Host "-t1:"; $sequentialBlocks | ForEach-Object { Write-Host "  $_" }
+        Write-Host "-t4:"; $parallelBlocks | ForEach-Object { Write-Host "  $_" }
         Exit-TestWithError "Scanning the blocks in parallel found different data"
     }
 
@@ -77,7 +77,7 @@ try {
     }
 
     # The repair must still work when the blocks were scanned in parallel
-    $repair = Invoke-Par2 -Arguments @("r", "-q", "-T4", "test.par2") -ReturnObject
+    $repair = Invoke-Par2 -Arguments @("r", "-q", "-t4", "test.par2") -ReturnObject
     if ($repair.ExitCode -ne 0) {
         Exit-TestWithError "Repair failed"
     }

--- a/tests/test47
+++ b/tests/test47
@@ -1,0 +1,113 @@
+#!/bin/sh
+
+execdir="$PWD"
+
+if [ -n "${PARVALGRINDOPTS+set}" ]
+then
+    PARBINARY="valgrind $PARVALGRINDOPTS $execdir/par2"
+elif [ "`which wine`" != "" ] && [ -f "$execdir/par2.exe" ]
+then
+    PARBINARY="wine $execdir/par2.exe"
+else
+    PARBINARY="$execdir/par2"
+fi
+
+if [ -z "$srcdir" ] || [ "." = "$srcdir" ]; then
+  srcdir="$PWD"
+  TESTDATA="$srcdir/tests"
+else
+  srcdir="$PWD/$srcdir"
+  TESTDATA="$srcdir/tests"
+fi
+
+TESTROOT="$PWD"
+
+testname=$(basename $0)
+rm -f "$testname.log"
+rm -rf "run$testname"
+
+mkdir "run$testname" && cd "run$testname" || { echo "ERROR: Could not change to test directory" ; exit 1; } >&2
+
+banner="Reading several files at once finds the same data"
+dashes=`echo "$banner" | sed s/./-/g`
+
+echo $dashes
+echo $banner
+echo $dashes
+
+# The -T option only exists when built with thread support
+if ! $PARBINARY -h 2>&1 | grep -q '^  -T<n>'; then
+    echo "Skipping: par2 was built without thread support."
+    cd "$TESTROOT"
+    rm -rf "run$testname"
+    exit 77
+fi
+
+# Build four data files of 16 blocks of 1024 bytes. Each file holds different
+# data so that a block cannot be matched against the wrong file.
+for n in 1 2 3 4
+do
+    i=0
+    while [ $i -lt 256 ]; do
+        printf '%s%063d' "$n" $i
+        i=$((i + 1))
+    done > "data$n.bin"
+    cp "data$n.bin" "data$n.bin.orig"
+done
+
+$PARBINARY c -q -s1024 -c20 test.par2 data1.bin data2.bin data3.bin data4.bin || { echo "ERROR: Could not create PAR2 files" ; exit 1; } >&2
+
+# data1.bin is left alone, so it is matched entirely where it is expected.
+
+# data2.bin has a gap holding nothing: block 3 is corrupt.
+printf 'XXXXXXXXXXXXXXXX' | dd of=data2.bin bs=1 seek=3072 conv=notrunc 2>/dev/null
+
+# data3.bin has a gap holding data: blocks 5 onwards are shifted forward by
+# half a block, so they are still in the file but not where they are expected.
+dd if=data3.bin of=region.bin bs=512 skip=10 count=20 2>/dev/null
+dd if=region.bin of=data3.bin bs=512 seek=11 conv=notrunc 2>/dev/null
+
+# data4.bin is truncated, so it cannot be a perfect match on length alone.
+dd if=data4.bin of=truncated.bin bs=1024 count=12 2>/dev/null
+mv truncated.bin data4.bin
+
+# Reading one file at a time gives each file every thread for its blocks.
+# Reading four at once shares those threads out between them. Both must find
+# the same data. The files are reported in whatever order they finish, so the
+# lines are sorted before they are compared.
+$PARBINARY v -T1 test.par2 > onefile.out 2>&1
+onefile=$?
+$PARBINARY v -T4 test.par2 > allfiles.out 2>&1
+allfiles=$?
+
+if [ $onefile -ne $allfiles ]
+then
+    echo "ERROR: Exit code differed: -T1 gave $onefile and -T4 gave $allfiles" >&2
+    exit 1
+fi
+
+# Strip the progress indicator, which is rewritten in place with \r
+tr '\r' '\n' < onefile.out | grep -E "Target:" | sort > onefile.blocks
+tr '\r' '\n' < allfiles.out | grep -E "Target:" | sort > allfiles.blocks
+
+if ! diff onefile.blocks allfiles.blocks
+then
+    echo "ERROR: Reading several files at once found different data" >&2
+    exit 1
+fi
+
+grep -q 'data1.bin" - found' allfiles.blocks || { echo "ERROR: Expected data1.bin to be found intact" ; cat allfiles.blocks ; exit 1; } >&2
+grep -q 'data2.bin" - damaged. Found 15 of 16 data blocks' allfiles.blocks || { echo "ERROR: Expected 15 of 16 blocks in data2.bin" ; cat allfiles.blocks ; exit 1; } >&2
+
+# The repair must still work when the files were read at the same time
+$PARBINARY r -q -T4 test.par2 || { echo "ERROR: Repair failed" ; exit 1; } >&2
+
+for n in 1 2 3 4
+do
+    cmp "data$n.bin" "data$n.bin.orig" || { echo "ERROR: Repaired data$n.bin does not match the original" ; exit 1; } >&2
+done
+
+cd "$TESTROOT"
+rm -rf "run$testname"
+
+exit 0

--- a/tests/test47.ps1
+++ b/tests/test47.ps1
@@ -1,0 +1,113 @@
+#!/usr/bin/env pwsh
+# Test 47: Reading several files at once finds the same data
+
+$ErrorActionPreference = "Stop"
+
+# Source common test functions
+. (Join-Path $PSScriptRoot "testfuncs.ps1")
+
+$testname = [System.IO.Path]::GetFileNameWithoutExtension($MyInvocation.MyCommand.Name)
+
+try {
+    Initialize-Test -TestName $testname
+
+    Write-Banner "Reading several files at once finds the same data"
+
+    # The -T option only exists when built with thread support
+    $help = Invoke-Par2 -Arguments @("-h") -ReturnObject
+    if ($help.StdOut -notmatch "(?m)^  -T<n>") {
+        Write-Host "Skipping: par2 was built without thread support."
+        Complete-Test
+        exit 77
+    }
+
+    # Build four data files of 16 blocks of 1024 bytes. Each file holds
+    # different data so that a block cannot be matched against the wrong file.
+    foreach ($n in 1..4) {
+        $builder = New-Object System.Text.StringBuilder
+        for ($i = 0; $i -lt 256; $i++) {
+            [void]$builder.Append($n.ToString() + $i.ToString("D63"))
+        }
+        [System.IO.File]::WriteAllText((Join-Path $PWD "data$n.bin"), $builder.ToString())
+        Copy-Item "data$n.bin" "data$n.bin.orig"
+    }
+
+    $create = Invoke-Par2 -Arguments @("c", "-q", "-s1024", "-c20", "test.par2", "data1.bin", "data2.bin", "data3.bin", "data4.bin") -ReturnObject
+    if ($create.ExitCode -ne 0) {
+        Exit-TestWithError "Could not create PAR2 files"
+    }
+
+    # data1.bin is left alone, so it is matched entirely where it is expected.
+
+    # data2.bin has a gap holding nothing: block 3 is corrupt.
+    $bytes = [System.IO.File]::ReadAllBytes((Join-Path $PWD "data2.bin"))
+    for ($i = 0; $i -lt 16; $i++) {
+        $bytes[3072 + $i] = [byte][char]'X'
+    }
+    [System.IO.File]::WriteAllBytes((Join-Path $PWD "data2.bin"), $bytes)
+
+    # data3.bin has a gap holding data: blocks 5 onwards are shifted forward by
+    # half a block, so they are still in the file but not where they are expected.
+    $bytes = [System.IO.File]::ReadAllBytes((Join-Path $PWD "data3.bin"))
+    $region = New-Object byte[] 10240
+    [System.Array]::Copy($bytes, 5120, $region, 0, 10240)
+    [System.Array]::Copy($region, 0, $bytes, 5632, 10240)
+    [System.IO.File]::WriteAllBytes((Join-Path $PWD "data3.bin"), $bytes)
+
+    # data4.bin is truncated, so it cannot be a perfect match on length alone.
+    $bytes = [System.IO.File]::ReadAllBytes((Join-Path $PWD "data4.bin"))
+    $truncated = New-Object byte[] 12288
+    [System.Array]::Copy($bytes, 0, $truncated, 0, 12288)
+    [System.IO.File]::WriteAllBytes((Join-Path $PWD "data4.bin"), $truncated)
+
+    # Reading one file at a time gives each file every thread for its blocks.
+    # Reading four at once shares those threads out between them. Both must find
+    # the same data. The files are reported in whatever order they finish, so the
+    # lines are sorted before they are compared.
+    $onefile = Invoke-Par2 -Arguments @("v", "-T1", "test.par2") -ReturnObject
+    $allfiles = Invoke-Par2 -Arguments @("v", "-T4", "test.par2") -ReturnObject
+
+    if ($onefile.ExitCode -ne $allfiles.ExitCode) {
+        Exit-TestWithError "Exit code differed: -T1 gave $($onefile.ExitCode) and -T4 gave $($allfiles.ExitCode)"
+    }
+
+    # Strip the progress indicator, which is rewritten in place with `r
+    $onefileBlocks = ($onefile.StdOut -replace "`r", "`n") -split "`n" | Where-Object { $_ -match "Target:" } | Sort-Object
+    $allfilesBlocks = ($allfiles.StdOut -replace "`r", "`n") -split "`n" | Where-Object { $_ -match "Target:" } | Sort-Object
+
+    if (($onefileBlocks -join "`n") -ne ($allfilesBlocks -join "`n")) {
+        Write-Host "-T1:"; $onefileBlocks | ForEach-Object { Write-Host "  $_" }
+        Write-Host "-T4:"; $allfilesBlocks | ForEach-Object { Write-Host "  $_" }
+        Exit-TestWithError "Reading several files at once found different data"
+    }
+
+    $joined = $allfilesBlocks -join "`n"
+
+    if ($joined -notmatch 'data1\.bin" - found') {
+        Exit-TestWithError "Expected data1.bin to be found intact"
+    }
+
+    if ($joined -notmatch 'data2\.bin" - damaged\. Found 15 of 16 data blocks') {
+        Exit-TestWithError "Expected 15 of 16 blocks in data2.bin"
+    }
+
+    # The repair must still work when the files were read at the same time
+    $repair = Invoke-Par2 -Arguments @("r", "-q", "-T4", "test.par2") -ReturnObject
+    if ($repair.ExitCode -ne 0) {
+        Exit-TestWithError "Repair failed"
+    }
+
+    foreach ($n in 1..4) {
+        if (-not (Compare-Files -File1 "data$n.bin" -File2 "data$n.bin.orig")) {
+            Exit-TestWithError "Repaired data$n.bin does not match the original"
+        }
+    }
+
+    Complete-Test
+    exit 0
+}
+catch {
+    Write-Host "ERROR: $_" -ForegroundColor Red
+    Complete-Test
+    exit 1
+}


### PR DESCRIPTION
This addresses some design issues described in #304

Each file now has a single thread which reads it sequentially (limit `-T`) and submits each block to workers (limit `-t`) shared by all files.
Each reader has two buffers, the one currently being hashed and the one being read in preparation for the next loop

- `DiskFile::Prefetch` removed
- `std::atomic` removed, along with issues around it
- block scan takes how many threads to use from `-t` rather than `-T`
- `-T` is clamped to `-t`, each reader buffers the next block which more than makes up for it and avoids oversubscribing the cpu

To keep it simple the share of hashers per file are fixed, rather than `#pragma omp atomic` and a counter - it would make it much more complex.

The reading thread can have the `force-full-hash-verify` opt-in for full file MD5 added later.

From the numbers I can see this is a much better approach.

@animetosho please take a look over if when you have a chance