### PR TITLE
Replace wstring_convert with the Win32 conversion functions

### DIFF
--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -43,6 +43,7 @@ static char THIS_FILE[]=__FILE__;
 
 #include "utf8.h"
 #include <cwctype>
+#include <iostream>
 
 #define OffsetType __int64
 #define MaxOffset 0x7fffffffffffffffI64
@@ -84,7 +85,13 @@ bool DiskFile::CreateParentDirectory(std::string _pathname)
       return true;
     }
 
-    std::wstring wpath = utf8::Utf8ToWide(path);
+    std::wstring wpath;
+    if (!utf8::Utf8ToWide(path, wpath))
+    {
+      #pragma omp critical(stdio)
+      *serr << "Could not convert \"" << path << "\" to a wide string." << std::endl;
+      return false;
+    }
 
     struct _stati64 st;
     if (_wstati64(wpath.c_str(), &st) == 0)
@@ -119,7 +126,14 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
     return false;
 
   // Create the file
-  std::wstring wfilename = utf8::Utf8ToWide(_filename);
+  std::wstring wfilename;
+  if (!utf8::Utf8ToWide(_filename, wfilename))
+  {
+    #pragma omp critical(stdio)
+    *serr << "Could not convert \"" << _filename << "\" to a wide string." << std::endl;
+    return false;
+  }
+
   hFile = ::CreateFileW(wfilename.c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_NEW, 0, NULL);
   if (hFile == INVALID_HANDLE_VALUE)
   {
@@ -248,7 +262,14 @@ bool DiskFile::Open(const std::string &_filename, u64 _filesize)
   filename = _filename;
   filesize = _filesize;
 
-  std::wstring wfilename = utf8::Utf8ToWide(_filename);
+  std::wstring wfilename;
+  if (!utf8::Utf8ToWide(_filename, wfilename))
+  {
+    #pragma omp critical(stdio)
+    *serr << "Could not convert \"" << _filename << "\" to a wide string." << std::endl;
+    return false;
+  }
+
   hFile = ::CreateFileW(wfilename.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
   if (hFile == INVALID_HANDLE_VALUE)
   {
@@ -341,7 +362,13 @@ void DiskFile::Close(void)
 
 std::string DiskFile::GetCanonicalPathname(std::string filename)
 {
-  std::wstring wfilename = utf8::Utf8ToWide(filename);
+  std::wstring wfilename;
+  if (!utf8::Utf8ToWide(filename, wfilename))
+  {
+    #pragma omp critical(stdio)
+    std::cerr << "Could not convert \"" << filename << "\" to a wide string." << std::endl;
+    return filename;
+  }
 
   // First call to get required buffer size
   DWORD length = GetFullPathNameW(wfilename.c_str(), 0, nullptr, nullptr);
@@ -363,7 +390,11 @@ std::string DiskFile::GetCanonicalPathname(std::string filename)
   wfullname[0] = towupper(wfullname[0]);
   std::replace(wfullname.get(), wfullname.get() + length, L'/', L'\\');
 
-  return utf8::WideToUtf8(wfullname.get());
+  std::string fullname;
+  if (!utf8::WideToUtf8(wfullname.get(), fullname))
+    return filename;
+
+  return fullname;
 }
 
 std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, std::string wildcard, bool recursive, bool followlinks)
@@ -376,7 +407,14 @@ std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, 
   }
   std::list<std::string> *matches = new std::list<std::string>;
 
-  std::wstring wwildcard = utf8::Utf8ToWide(path + wildcard);
+  std::wstring wwildcard;
+  if (!utf8::Utf8ToWide(path + wildcard, wwildcard))
+  {
+    #pragma omp critical(stdio)
+    std::cerr << "Could not convert \"" << path + wildcard << "\" to a wide string." << std::endl;
+    return std::unique_ptr< std::list<std::string> >(matches);
+  }
+
   WIN32_FIND_DATAW fd;
   HANDLE h = ::FindFirstFileW(wwildcard.c_str(), &fd);
   if (h != INVALID_HANDLE_VALUE)
@@ -385,7 +423,9 @@ std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, 
     {
       if (0 == (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
       {
-        matches->push_back(path + utf8::WideToUtf8(fd.cFileName));
+        std::string name;
+        if (utf8::WideToUtf8(fd.cFileName, name))
+          matches->push_back(path + name);
       }
       else if (recursive == true)
       {
@@ -393,13 +433,18 @@ std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, 
           continue;
         }
 
+        std::string name;
+        if (!utf8::WideToUtf8(fd.cFileName, name))
+          continue;
+
         std::string nwwildcard="*";
-	std::unique_ptr< std::list<std::string> > dirmatches(
-						 DiskFile::FindFiles(path + utf8::WideToUtf8(fd.cFileName), nwwildcard, true, followlinks)
-						 );
+        std::unique_ptr< std::list<std::string> > dirmatches(
+          DiskFile::FindFiles(path + name, nwwildcard, true, followlinks)
+        );
 
         // append without requiring ordering
-        matches->splice(matches->end(), *dirmatches);
+        if (dirmatches)
+          matches->splice(matches->end(), *dirmatches);
       }
     } while (::FindNextFileW(h, &fd));
     ::FindClose(h);
@@ -410,7 +455,14 @@ std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, 
 
 u64 DiskFile::GetFileSize(std::string filename)
 {
-  std::wstring wfilename = utf8::Utf8ToWide(filename);
+  std::wstring wfilename;
+  if (!utf8::Utf8ToWide(filename, wfilename))
+  {
+    #pragma omp critical(stdio)
+    std::cerr << "Could not convert \"" << filename << "\" to a wide string." << std::endl;
+    return 0;
+  }
+
   struct _stati64 st;
   if ((0 == _wstati64(wfilename.c_str(), &st)) && (0 != (st.st_mode & S_IFREG)))
   {
@@ -424,9 +476,16 @@ u64 DiskFile::GetFileSize(std::string filename)
 
 bool DiskFile::FileExists(std::string filename)
 {
-  std::wstring wfilename = utf8::Utf8ToWide(filename);
+  std::wstring wfilename;
+  if (!utf8::Utf8ToWide(filename, wfilename))
+  {
+    #pragma omp critical(stdio)
+    std::cerr << "Could not convert \"" << filename << "\" to a wide string." << std::endl;
+    return false;
+  }
+
   struct _stati64 st;
-  return ((0 == _wstati64(wfilename.c_str(), &st)) && (0 != (st.st_mode & _S_IFREG))); 
+  return ((0 == _wstati64(wfilename.c_str(), &st)) && (0 != (st.st_mode & _S_IFREG)));
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -962,8 +1021,8 @@ bool DiskFile::Delete(void)
 #ifdef _WIN32
   assert(hFile == INVALID_HANDLE_VALUE);
 
-  std::wstring wfilename = utf8::Utf8ToWide(filename);
-  if (filename.size() > 0 && ::DeleteFileW(wfilename.c_str()))
+  std::wstring wfilename;
+  if (!filename.empty() && utf8::Utf8ToWide(filename, wfilename) && ::DeleteFileW(wfilename.c_str()))
   {
     exists = false;
     return true;
@@ -1045,7 +1104,12 @@ bool DiskFile::Rename(void)
       return false;
     }
 
-    wnewname = utf8::Utf8ToWide(newname);
+    if (!utf8::Utf8ToWide(newname, wnewname))
+    {
+      #pragma omp critical(stdio)
+      *serr << "Could not convert \"" << newname << "\" to a wide string." << std::endl;
+      return false;
+    }
 
     // Check if file exists using wide-character stat
   } while (_wstati64(wnewname.c_str(), &st) == 0);
@@ -1080,8 +1144,6 @@ bool DiskFile::Rename(void)
 #ifdef _WIN32
 std::string DiskFile::ErrorMessage(DWORD error)
 {
-  std::string result;
-
   LPVOID lpMsgBuf;
   if (::FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                        NULL,
@@ -1091,27 +1153,28 @@ std::string DiskFile::ErrorMessage(DWORD error)
                        0,
                        NULL))
   {
-    result = utf8::WideToUtf8((wchar_t*)lpMsgBuf);
+    std::string converted;
+    const bool ok = utf8::WideToUtf8((wchar_t*)lpMsgBuf, converted);
     LocalFree(lpMsgBuf);
-  }
-  else
-  {
-    char message[40];
-    snprintf(message, sizeof(message), "Unknown error code (%lu)", error);
-    result = message;
+
+    if (ok)
+    {
+      return converted;
+    }
   }
 
-  return result;
+  char message[40];
+  snprintf(message, sizeof(message), "Unknown error code (%lu)", error);
+
+  return message;
 }
 
 bool DiskFile::Rename(std::string _filename)
 {
   assert(hFile == INVALID_HANDLE_VALUE);
 
-  std::wstring wfilename = utf8::Utf8ToWide(filename);
-  std::wstring _wfilename = utf8::Utf8ToWide(_filename);
-
-  if (::MoveFileW(wfilename.c_str(), _wfilename.c_str()))
+  std::wstring wfilename, _wfilename;
+  if (utf8::Utf8ToWide(filename, wfilename) && utf8::Utf8ToWide(_filename, _wfilename) && ::MoveFileW(wfilename.c_str(), _wfilename.c_str()))
   {
     filename.swap(_filename);
 

--- a/src/libpar2internal.h
+++ b/src/libpar2internal.h
@@ -193,7 +193,6 @@ typedef unsigned int     size_t;
 
 #include <ctype.h>
 #include <iomanip>
-#include <codecvt>
 
 #include <cassert>
 

--- a/src/par2cmdline.cpp
+++ b/src/par2cmdline.cpp
@@ -53,6 +53,7 @@ int main(int argc, char* argv[])
 
   utf8::WideToUtf8ArgsAdapter wargsAdapter{ argc, wargv };
   auto argv = wargsAdapter.GetUtf8Args();
+  argc = wargsAdapter.GetArgc();
 #endif
 
   // check sizeof integers

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -42,7 +42,7 @@ namespace utf8
 
     if (wpath.compare(0, 2, L"\\\\") == 0)
     {
-      wpath = L"\\\\?\\UNC" + wpath;
+      wpath = L"\\\\?\\UNC" + wpath.substr(1);
     }
     else
     {

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -19,9 +19,11 @@
 
 #include "libpar2internal.h"
 
+#ifdef _WIN32
+
 #include <cstring>
 #include <iostream>
-#include <exception>
+#include <stdexcept>
 
 #include "utf8.h"
 
@@ -29,58 +31,104 @@ namespace utf8
 {
   const int MAX_ARGS = 128;
   const size_t MAX_DIR_PATH = 248;
-  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> UTF8_CONVERTER;
 
-  std::wstring Utf8ToWide(const std::string& str)
+  static void ApplyLongPathPrefix(std::wstring& wpath)
   {
-    if (str.empty())
-      return L"";
-
-    try
+    if (wpath.size() <= MAX_DIR_PATH ||
+      wpath.find(L"\\\\?\\") != std::wstring::npos)
     {
-      std::wstring wpath = UTF8_CONVERTER.from_bytes(str.c_str());
-
-      if (wpath.size() > MAX_DIR_PATH &&
-        wpath.find(L"\\\\?\\") == std::wstring::npos &&
-        wpath.find(L"\\\\?\\UNC") == std::wstring::npos)
-      {
-        if (std::wcsncmp(wpath.c_str(), L"\\\\", 2) == 0)
-        {
-          wpath = L"\\\\?\\UNC" + wpath;
-        }
-        else
-        {
-          wpath = L"\\\\?\\" + wpath;
-        }
-      }
-
-      return wpath;
+      return;
     }
-    catch (const std::exception& e)
+
+    if (wpath.compare(0, 2, L"\\\\") == 0)
     {
-      std::cerr << "Failed to convert UTF-8 to wide string: " << e.what() << std::endl;
-      return L"";
+      wpath = L"\\\\?\\UNC" + wpath;
+    }
+    else
+    {
+      wpath = L"\\\\?\\" + wpath;
     }
   }
 
-  std::string WideToUtf8(const std::wstring& str)
+  bool Utf8ToWide(const std::string& str, std::wstring& out)
   {
     if (str.empty())
-      return "";
+    {
+      out.clear();
+      return true;
+    }
 
-    try
+    const int length = (int)str.size();
+    const int required = ::MultiByteToWideChar(
+      CP_UTF8,
+      MB_ERR_INVALID_CHARS,
+      str.c_str(),
+      length,
+      nullptr,
+      0
+    );
+    if (required <= 0)
+      return false;
+
+    std::wstring wpath(required, L'\0');
+    if (::MultiByteToWideChar(
+      CP_UTF8,
+      MB_ERR_INVALID_CHARS,
+      str.c_str(),
+      length,
+      &wpath[0],
+      required
+    ) <= 0)
+      return false;
+
+    ApplyLongPathPrefix(wpath);
+
+    out.swap(wpath);
+    return true;
+  }
+
+  bool WideToUtf8(const std::wstring& str, std::string& out)
+  {
+    if (str.empty())
     {
-      return UTF8_CONVERTER.to_bytes(str.c_str());
+      out.clear();
+      return true;
     }
-    catch (const std::exception& e)
-    {
-      std::cerr << "Failed to convert wide to UTF-8 string: " << e.what() << std::endl;
-      return "";
-    }
+
+    const int length = (int)str.size();
+    const int required = ::WideCharToMultiByte(
+      CP_UTF8,
+      WC_ERR_INVALID_CHARS,
+      str.c_str(),
+      length,
+      nullptr,
+      0,
+      nullptr,
+      nullptr
+    );
+    if (required <= 0)
+      return false;
+
+    std::string utf8(required, '\0');
+    if (::WideCharToMultiByte(
+      CP_UTF8,
+      WC_ERR_INVALID_CHARS,
+      str.c_str(),
+      length,
+      &utf8[0],
+      required,
+      nullptr,
+      nullptr
+    ) <= 0)
+      return false;
+
+    out.swap(utf8);
+    return true;
   }
 
   WideToUtf8ArgsAdapter::WideToUtf8ArgsAdapter(int argc, wchar_t* wargv[]) noexcept(false)
-    : m_argc(argc)
+    : m_argv(nullptr)
+    , m_argc(argc)
   {
     if (wargv == nullptr)
     {
@@ -97,23 +145,34 @@ namespace utf8
     }
 
     m_argv = new char* [m_argc + 1];
+
+    int argcount = 0;
     for (int i = 0; i < m_argc; ++i)
     {
       if (wargv[i] == nullptr)
       {
         std::cerr
           << "Invalid argument: encountered nullptr in wargv.\n"
-             "Skipping " << i << "argument." << std::endl;
-        --m_argc;
-        --i;
+             "Skipping argument " << i << "." << std::endl;
         continue;
       }
 
-      std::string arg = WideToUtf8(wargv[i]);
-      size_t size = arg.size() + 1;
-      m_argv[i] = new char[size];
-      std::memcpy(m_argv[i], arg.c_str(), size);
+      std::string arg;
+      if (!WideToUtf8(wargv[i], arg))
+      {
+        std::cerr
+          << "Failed to convert wide to UTF-8 string.\n"
+             "Skipping argument " << i << "." << std::endl;
+        continue;
+      }
+
+      const size_t size = arg.size() + 1;
+      m_argv[argcount] = new char[size];
+      std::memcpy(m_argv[argcount], arg.c_str(), size);
+      ++argcount;
     }
+
+    m_argc = argcount;
     m_argv[m_argc] = nullptr;
   }
 
@@ -122,11 +181,16 @@ namespace utf8
     return m_argv;
   }
 
+  int WideToUtf8ArgsAdapter::GetArgc() const noexcept
+  {
+    return m_argc;
+  }
+
   WideToUtf8ArgsAdapter::~WideToUtf8ArgsAdapter()
   {
     if (m_argv)
     {
-      for (size_t i = 0; m_argv[i]; ++i)
+      for (int i = 0; i < m_argc; ++i)
       {
         delete[] m_argv[i];
       }
@@ -134,3 +198,5 @@ namespace utf8
     }
   }
 }
+
+#endif // _WIN32

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -20,18 +20,20 @@
 #ifndef __UTF8_H__
 #define __UTF8_H__
 
+#ifdef _WIN32
+
 #include <string>
-#include <locale>
-#include <codecvt>
 
 namespace utf8
 {
   extern const int MAX_ARGS;
   extern const size_t MAX_DIR_PATH;
-  extern std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> UTF8_CONVERTER;
 
-  std::wstring Utf8ToWide(const std::string& str);
-  std::string WideToUtf8(const std::wstring& str);
+  // False if the string is not well formed, leaving out untouched. Otherwise out
+  // holds the conversion, and a path longer than MAX_DIR_PATH has gained a
+  // \\?\ or \\?\UNC prefix so that the Win32 calls accept it.
+  bool Utf8ToWide(const std::string& str, std::wstring& out);
+  bool WideToUtf8(const std::wstring& str, std::string& out);
 
   class WideToUtf8ArgsAdapter final
   {
@@ -39,6 +41,10 @@ namespace utf8
     WideToUtf8ArgsAdapter(int argc, wchar_t* argv_[]) noexcept(false);
 
     const char* const* GetUtf8Args() const noexcept;
+
+    // The number of arguments in GetUtf8Args(), which is less than the argc
+    // passed in when an argument could not be used.
+    int GetArgc() const noexcept;
 
     WideToUtf8ArgsAdapter() = delete;
     WideToUtf8ArgsAdapter(const WideToUtf8ArgsAdapter&) = delete;
@@ -53,5 +59,7 @@ namespace utf8
     int m_argc;
   };
 }
+
+#endif // _WIN32
 
 #endif // __UTF8_H__

--- a/src/utf8_test.cpp
+++ b/src/utf8_test.cpp
@@ -178,6 +178,30 @@ int test8()
   return 0;
 }
 
+int test9()
+{
+  std::wstring shortpath;
+  if (!Utf8ToWide("C:\\short", shortpath))
+    return 1;
+  if (shortpath != std::wstring(L"C:\\short"))
+    return 1;
+
+  std::string longpath = "C:\\" + std::string(MAX_DIR_PATH, 'a');
+  std::wstring widelong;
+  if (!Utf8ToWide(longpath, widelong))
+    return 1;
+  if (widelong != L"\\\\?\\C:\\" + std::wstring(MAX_DIR_PATH, L'a'))
+    return 1;
+
+  std::string uncpath = "\\\\server\\" + std::string(MAX_DIR_PATH, 'b');
+  std::wstring wideunc;
+  if (!Utf8ToWide(uncpath, wideunc))
+    return 1;
+  if (wideunc != L"\\\\?\\UNC\\server\\" + std::wstring(MAX_DIR_PATH, L'b'))
+    return 1;
+
+  return 0;
+}
 
 int main()
 {
@@ -226,6 +250,12 @@ int main()
   if (test8())
   {
     std::cerr << "FAILED: test8" << std::endl;
+    return 1;
+  }
+
+  if (test9())
+  {
+    std::cerr << "FAILED: test9" << std::endl;
     return 1;
   }
 

--- a/src/utf8_test.cpp
+++ b/src/utf8_test.cpp
@@ -20,6 +20,10 @@
 #include "libpar2internal.h"
 
 #include <iostream>
+
+#ifdef _WIN32
+
+#include <string>
 #include "utf8.h"
 
 
@@ -29,10 +33,14 @@ int test1()
 {
   std::string emptyString = "";
   std::wstring expectedWide = L"";
-  std::wstring actualWide = Utf8ToWide(emptyString);
+  std::wstring actualWide;
+  if (!Utf8ToWide(emptyString, actualWide))
+    return 1;
 
   std::string expectedUtf8 = "";
-  std::string actualUtf8 = WideToUtf8(expectedWide);
+  std::string actualUtf8;
+  if (!WideToUtf8(expectedWide, actualUtf8))
+    return 1;
 
   if (actualWide == expectedWide && actualUtf8 == expectedUtf8)
     return 0;
@@ -44,10 +52,14 @@ int test2()
 {
   std::string asciiString = "Hello, World!";
   std::wstring expectedWide = L"Hello, World!";
-  std::wstring actualWide = Utf8ToWide(asciiString);
+  std::wstring actualWide;
+  if (!Utf8ToWide(asciiString, actualWide))
+    return 1;
 
   std::string expectedUtf8 = "Hello, World!";
-  std::string actualUtf8 = WideToUtf8(expectedWide);
+  std::string actualUtf8;
+  if (!WideToUtf8(expectedWide, actualUtf8))
+    return 1;
 
   if (actualWide == expectedWide && actualUtf8 == expectedUtf8)
     return 0;
@@ -60,10 +72,14 @@ int test3()
   // "Привет, мир!"
   std::string nonAsciiString = "\xD0\x9F\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82, \xD0\xBC\xD0\xB8\xD1\x80!";
   std::wstring expectedWide = L"\x041F\x0440\x0438\x0432\x0435\x0442, \x043C\x0438\x0440!";
-  std::wstring actualWide = Utf8ToWide(nonAsciiString);
+  std::wstring actualWide;
+  if (!Utf8ToWide(nonAsciiString, actualWide))
+    return 1;
 
   std::string expectedUtf8 = "\xD0\x9F\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82, \xD0\xBC\xD0\xB8\xD1\x80!";
-  std::string actualUtf8 = WideToUtf8(expectedWide);
+  std::string actualUtf8;
+  if (!WideToUtf8(expectedWide, actualUtf8))
+    return 1;
 
   if (actualWide == expectedWide && actualUtf8 == expectedUtf8)
     return 0;
@@ -75,10 +91,14 @@ int test4()
 {
   std::string specialCharsString = "This string has: !@#$%^&*()_+=-`~[]{}:;'<>,.?/";
   std::wstring expectedWide = L"This string has: !@#$%^&*()_+=-`~[]{}:;'<>,.?/";
-  std::wstring actualWide = Utf8ToWide(specialCharsString);
+  std::wstring actualWide;
+  if (!Utf8ToWide(specialCharsString, actualWide))
+    return 1;
 
   std::string expectedUtf8 = "This string has: !@#$%^&*()_+=-`~[]{}:;'<>,.?/";
-  std::string actualUtf8 = WideToUtf8(expectedWide);
+  std::string actualUtf8;
+  if (!WideToUtf8(expectedWide, actualUtf8))
+    return 1;
 
   if (actualWide == expectedWide && actualUtf8 == expectedUtf8)
     return 0;
@@ -91,10 +111,14 @@ int test5()
   // "Привет! こんにちは世界! 안녕하세요!"
   std::string multiLangString = "\xD0\x9F\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82! \xE3\x81\x93\xE3\x82\x93\xE3\x81\xAB\xE3\x81\xA1\xE3\x81\xAF\xE4\xB8\x96\xE7\x95\x8C! \xEC\x95\x88\xEB\x85\x95\xED\x95\x98\xEC\x84\xB8\xEC\x9A\x94!";
   std::wstring expectedWide = L"\x041F\x0440\x0438\x0432\x0435\x0442! \x3053\x3093\x306B\x3061\x306F\x4E16\x754C! \xC548\xB155\xD558\xC138\xC694!";
-  std::wstring actualWide = Utf8ToWide(multiLangString);
+  std::wstring actualWide;
+  if (!Utf8ToWide(multiLangString, actualWide))
+    return 1;
 
   std::string expectedUtf8 = "\xD0\x9F\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82! \xE3\x81\x93\xE3\x82\x93\xE3\x81\xAB\xE3\x81\xA1\xE3\x81\xAF\xE4\xB8\x96\xE7\x95\x8C! \xEC\x95\x88\xEB\x85\x95\xED\x95\x98\xEC\x84\xB8\xEC\x9A\x94!";
-  std::string actualUtf8 = WideToUtf8(expectedWide);
+  std::string actualUtf8;
+  if (!WideToUtf8(expectedWide, actualUtf8))
+    return 1;
 
   if (actualWide == expectedWide && actualUtf8 == expectedUtf8)
     return 0;
@@ -119,7 +143,12 @@ int test7()
   const char* const* utf8Args = adapter.GetUtf8Args();
 
   for (int i = 0; i < 3; ++i) {
-    if (WideToUtf8(wargv[i]) != std::string(utf8Args[i]))
+    std::string converted;
+    if (!WideToUtf8(wargv[i], converted))
+    {
+      return 1;
+    }
+    if (converted != std::string(utf8Args[i]))
     {
       return 1;
     }
@@ -133,24 +162,22 @@ int test8()
   wchar_t* wargv[3] = { const_cast<wchar_t*>(L"arg1"), nullptr, const_cast<wchar_t*>(L"arg3") };
   WideToUtf8ArgsAdapter adapter(3, wargv);
   const char* const* utf8Args = adapter.GetUtf8Args();
-  int argc = 3;
-  for (int i = 0; i < argc; ++i)
-  {
-    if (wargv[i] == nullptr)
-    {
-      --i;
-      --argc;
-      continue;
-    }
 
-    if (WideToUtf8(wargv[i]) != std::string(utf8Args[i]))
-    {
-      return 1;
-    }
-  }
+  if (std::string(utf8Args[0]) != "arg1")
+    return 1;
+
+  if (std::string(utf8Args[1]) != "arg3")
+    return 1;
+
+  if (utf8Args[2] != nullptr)
+    return 1;
+
+  if (adapter.GetArgc() != 2)
+    return 1;
 
   return 0;
 }
+
 
 int main()
 {
@@ -206,3 +233,16 @@ int main()
 
   return 0;
 }
+
+#else // !_WIN32
+
+int main()
+{
+  std::cout << "utf8 conversion is only built on Windows." << std::endl;
+
+  // 77 is the exit status automake reports as SKIP, so this does not read as a
+  // test that ran and passed
+  return 77;
+}
+
+#endif

--- a/tests/unit_tests
+++ b/tests/unit_tests
@@ -20,7 +20,14 @@ do
 	PARBINARY="$f"
     fi
 
-    $PARBINARY || { echo "ERROR: $f failed." ; exit 1; } >&2
+    # 77 is the exit status for a test that does not apply on this platform
+    $PARBINARY
+    status=$?
+    if [ $status -ne 0 ] && [ $status -ne 77 ]
+    then
+        echo "ERROR: $f failed." >&2
+        exit 1
+    fi
 
     echo "------------------------------------------------------"
     echo "Unit test complete for file $f"
@@ -38,7 +45,13 @@ do
     echo "Running unit tests from file $f"
     echo "------------------------------------------------------"
 
-    wine $f || { echo "ERROR: $f failed." ; exit 1; } >&2
+    wine $f
+    status=$?
+    if [ $status -ne 0 ] && [ $status -ne 77 ]
+    then
+        echo "ERROR: $f failed." >&2
+        exit 1
+    fi
 
     echo "------------------------------------------------------"
     echo "Unit test complete for file $f"


### PR DESCRIPTION
`<codecvt>` and `std::wstring_convert` were deprecated in C++17 and are removed in C++26, so `utf8.cpp` has to move off them eventually. This replaces them with `MultiByteToWideChar`/`WideCharToMultiByte`.

`MB_ERR_INVALID_CHARS` and `WC_ERR_INVALID_CHARS` are not new strictness, they preserve the old behaviour.
`wstring_convert` threw `std::range_error` on ill-formed input and the code caught it; without those flags the replacement would silently substitute U+FFFD instead.
The conversions now return `bool` and report failure to the caller rather than logging and returning an empty string. Since they no longer log, the `DiskFile` callers that previously just gave up now say which path they could not convert, instead of failing with no diagnostic at all.

Two bugs fixed:

- The long-path prefix for UNC paths doubled the separator, producing `\\?\UNC\\server\share`
- `WideToUtf8ArgsAdapter` mishandled a null in `wargv`: `--m_argc; --i; continue;`  re-examines the same index while shrinking the count, so one null argument dropped every argument.
  The adapter compacts `argv` and null-terminates it at the new count, so it now exposes `GetArgc()` and `wmain` passes that to `CommandLine::Parse`. With the original `argc`, `ReadArgs` walks past the NULL terminator and dereferences it — that also applies to the `MAX_ARGS` clamp, which reads uninitialised pointers once more than 128 arguments are given.

`utf8.{h,cpp}` is now `#ifdef _WIN32`, since it is Win32-only; the unit test exits 77 (SKIP) elsewhere.
