### PR TITLE
Count the tail of a scanned file when built without OpenMP

### DIFF
--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -2045,13 +2045,11 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
     }
   }
 
-#ifdef _OPENMP
   if (noiselevel > nlQuiet)
   {
     if (filechecksummer.Offset() >= rangeend)
       progress.Add(filechecksummer.Offset() - oldoffset);
   }
-#endif
 
   if (lastmatchoffset < filechecksummer.Offset() && noiselevel > nlNormal)
   {


### PR DESCRIPTION
Builds without OpenMP don't report the final 1000 progress