### PR TITLE
Suppress reachable blocks from libgomp init and sync_with_stdio

### DIFF
--- a/tests/test43
+++ b/tests/test43
@@ -42,10 +42,10 @@ printf 'symlink escape file body\n' > work/.config/autostart/poc.desktop
 
 (
   cd work || exit 1
-  "$PARBINARY" c -q -r100 recovery.par2 .config/autostart/poc.desktop >/dev/null || exit 1
+  $PARBINARY c -q -r100 recovery.par2 .config/autostart/poc.desktop >/dev/null || exit 1
   rm .config/autostart/poc.desktop
   ln -s "$PWD/../outside/escaped-by-repair" .config/autostart/poc.desktop
-  "$PARBINARY" r -q recovery.par2 >/dev/null && exit 2
+  $PARBINARY r -q recovery.par2 >/dev/null && exit 2
   exit 0
 )
 status=$?

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -12,3 +12,27 @@
    fun:pthread_create*
    obj:*/libgomp.so*
 }
+
+# libgomp allocates its global state from an ELF constructor when the library
+# is loaded, and its per-team state on entry to a parallel region. Both are
+# held inside the runtime until the process exits
+{
+   libgomp_internal_state
+   Memcheck:Leak
+   match-leak-kinds: possible,reachable
+   fun:*
+   obj:*/libgomp.so*
+   obj:*/libgomp.so*
+}
+
+# Unsynchronising the C++ streams from C stdio gives cin/cout/cerr and their
+# wide counterparts their own filebufs, whose buffers belong to static objects
+# and are never freed
+{
+   libstdcxx_sync_with_stdio_buffers
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znam
+   ...
+   fun:_ZNSt8ios_base15sync_with_stdioEb
+}


### PR DESCRIPTION
libgomp from parallel pool
sync_with_stdio_buffers from 4ea66867010fa8b4131caef4cba41a2f2e7dbe1c