### PR TITLE
Replace the OpenMP critical sections and atomics with the standard library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,23 @@ AC_FUNC_FSEEKO
 dnl Check for OpenMP
 AC_OPENMP
 
+dnl ProgressMeter keeps 64-bit counters in std::atomic. Most targets emit those
+dnl inline, but 32-bit ones generally need libatomic to supply them.
+AC_MSG_CHECKING([whether 64-bit atomics need libatomic])
+m4_define([PAR2_ATOMIC_PROGRAM], [AC_LANG_PROGRAM(
+  [[#include <atomic>
+    #include <cstdint>]],
+  [[std::atomic<uint64_t> value(0); return (int)value.fetch_add(1);]])])
+AC_LINK_IFELSE([PAR2_ATOMIC_PROGRAM],
+  [AC_MSG_RESULT([no])],
+  [par2_saved_LIBS=$LIBS
+   LIBS="$LIBS -latomic"
+   AC_LINK_IFELSE([PAR2_ATOMIC_PROGRAM],
+     [AC_MSG_RESULT([yes])],
+     [AC_MSG_RESULT([no])
+      LIBS=$par2_saved_LIBS
+      AC_MSG_ERROR([par2cmdline needs 64-bit atomics])])])
+
 dnl Checks for library functions.
 AC_FUNC_MEMCMP
 AC_CHECK_FUNCS([stricmp] [strcasecmp])

--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -88,8 +88,7 @@ bool DiskFile::CreateParentDirectory(std::string _pathname)
     std::wstring wpath;
     if (!utf8::Utf8ToWide(path, wpath))
     {
-      #pragma omp critical(stdio)
-      *serr << "Could not convert \"" << path << "\" to a wide string." << std::endl;
+      LockedStream(*serr) << "Could not convert \"" << path << "\" to a wide string." << std::endl;
       return false;
     }
 
@@ -104,8 +103,7 @@ bool DiskFile::CreateParentDirectory(std::string _pathname)
     {
       DWORD error = ::GetLastError();
 
-      #pragma omp critical(stdio)
-      *serr << "Could not create the " << path << " directory: " << ErrorMessage(error) << std::endl;
+      LockedStream(*serr) << "Could not create the " << path << " directory: " << ErrorMessage(error) << std::endl;
 
       return false;
     }
@@ -129,8 +127,7 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
   std::wstring wfilename;
   if (!utf8::Utf8ToWide(_filename, wfilename))
   {
-    #pragma omp critical(stdio)
-    *serr << "Could not convert \"" << _filename << "\" to a wide string." << std::endl;
+    LockedStream(*serr) << "Could not convert \"" << _filename << "\" to a wide string." << std::endl;
     return false;
   }
 
@@ -139,8 +136,7 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
   {
     DWORD error = ::GetLastError();
 
-    #pragma omp critical(stdio)
-    *serr << "Could not create \"" << _filename << "\": " << ErrorMessage(error) << std::endl;
+    LockedStream(*serr) << "Could not create \"" << _filename << "\": " << ErrorMessage(error) << std::endl;
 
     return false;
   }
@@ -156,8 +152,7 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
     {
       DWORD error = ::GetLastError();
 
-      #pragma omp critical(stdio)
-      *serr << "Could not set size of \"" << _filename << "\": " << ErrorMessage(error) << std::endl;
+      LockedStream(*serr) << "Could not set size of \"" << _filename << "\": " << ErrorMessage(error) << std::endl;
 
       ::CloseHandle(hFile);
       hFile = INVALID_HANDLE_VALUE;
@@ -171,8 +166,7 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
     {
       DWORD error = ::GetLastError();
 
-      #pragma omp critical(stdio)
-      *serr << "Could not set size of \"" << _filename << "\": " << ErrorMessage(error) << std::endl;
+      LockedStream(*serr) << "Could not set size of \"" << _filename << "\": " << ErrorMessage(error) << std::endl;
 
       ::CloseHandle(hFile);
       hFile = INVALID_HANDLE_VALUE;
@@ -205,8 +199,7 @@ bool DiskFile::Write(u64 _offset, const void *buffer, size_t length, LengthType 
     {
       DWORD error = ::GetLastError();
 
-      #pragma omp critical(stdio)
-      *serr << "Could not write " << (u64)length << " bytes to \"" << filename << "\" at offset " << _offset << ": " << ErrorMessage(error) << std::endl;
+      LockedStream(*serr) << "Could not write " << (u64)length << " bytes to \"" << filename << "\" at offset " << _offset << ": " << ErrorMessage(error) << std::endl;
 
       return false;
     }
@@ -228,16 +221,14 @@ bool DiskFile::Write(u64 _offset, const void *buffer, size_t length, LengthType 
     {
       DWORD error = ::GetLastError();
 
-      #pragma omp critical(stdio)
-      *serr << "Could not write " << write << " bytes to \"" << filename << "\" at offset " << _offset << ": " << ErrorMessage(error) << std::endl;
+      LockedStream(*serr) << "Could not write " << write << " bytes to \"" << filename << "\" at offset " << _offset << ": " << ErrorMessage(error) << std::endl;
 
       return false;
     }
 
     if (wrote != write)
     {
-      #pragma omp critical(stdio)
-      *serr << "INFO: Incomplete write to \"" << filename << "\" at offset " << _offset << ".  Expected to write " << write << " bytes and wrote " << wrote << " bytes." << std::endl;
+      LockedStream(*serr) << "INFO: Incomplete write to \"" << filename << "\" at offset " << _offset << ".  Expected to write " << write << " bytes and wrote " << wrote << " bytes." << std::endl;
     }
 
     offset += wrote;
@@ -265,8 +256,7 @@ bool DiskFile::Open(const std::string &_filename, u64 _filesize)
   std::wstring wfilename;
   if (!utf8::Utf8ToWide(_filename, wfilename))
   {
-    #pragma omp critical(stdio)
-    *serr << "Could not convert \"" << _filename << "\" to a wide string." << std::endl;
+    LockedStream(*serr) << "Could not convert \"" << _filename << "\" to a wide string." << std::endl;
     return false;
   }
 
@@ -281,8 +271,7 @@ bool DiskFile::Open(const std::string &_filename, u64 _filesize)
     case ERROR_PATH_NOT_FOUND:
       break;
     default:
-      #pragma omp critical(stdio)
-      *serr << "Could not open \"" << _filename << "\": " << ErrorMessage(error) << std::endl;
+      LockedStream(*serr) << "Could not open \"" << _filename << "\": " << ErrorMessage(error) << std::endl;
     }
 
     return false;
@@ -323,24 +312,21 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxleng
     {
       DWORD error = ::GetLastError();
 
-      #pragma omp critical(stdio)
-      *serr << "Could not read " << (u64)length << " bytes from \"" << filename << "\" at offset " << _offset << ": " << ErrorMessage(error) << std::endl;
+      LockedStream(*serr) << "Could not read " << (u64)length << " bytes from \"" << filename << "\" at offset " << _offset << ": " << ErrorMessage(error) << std::endl;
 
       return false;
     }
 
     if (got == 0)
     {
-      #pragma omp critical(stdio)
-      *serr << "Could not read " << (u64)length << " bytes from \"" << filename << "\" at offset " << _offset << ": unexpected end of file." << std::endl;
+      LockedStream(*serr) << "Could not read " << (u64)length << " bytes from \"" << filename << "\" at offset " << _offset << ": unexpected end of file." << std::endl;
 
       return false;
     }
 
     if (want != got)
     {
-      #pragma omp critical(stdio)
-      *serr << "Incomplete read from \"" << filename << "\" at offset " << _offset << ".  Tried to read " << want << " bytes and received " << got << " bytes." << std::endl;
+      LockedStream(*serr) << "Incomplete read from \"" << filename << "\" at offset " << _offset << ".  Tried to read " << want << " bytes and received " << got << " bytes." << std::endl;
     }
 
     _offset += got;
@@ -365,8 +351,7 @@ std::string DiskFile::GetCanonicalPathname(std::string filename)
   std::wstring wfilename;
   if (!utf8::Utf8ToWide(filename, wfilename))
   {
-    #pragma omp critical(stdio)
-    std::cerr << "Could not convert \"" << filename << "\" to a wide string." << std::endl;
+    LockedStream(std::cerr) << "Could not convert \"" << filename << "\" to a wide string." << std::endl;
     return filename;
   }
 
@@ -410,8 +395,7 @@ std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, 
   std::wstring wwildcard;
   if (!utf8::Utf8ToWide(path + wildcard, wwildcard))
   {
-    #pragma omp critical(stdio)
-    std::cerr << "Could not convert \"" << path + wildcard << "\" to a wide string." << std::endl;
+    LockedStream(std::cerr) << "Could not convert \"" << path + wildcard << "\" to a wide string." << std::endl;
     return std::unique_ptr< std::list<std::string> >(matches);
   }
 
@@ -458,8 +442,7 @@ u64 DiskFile::GetFileSize(std::string filename)
   std::wstring wfilename;
   if (!utf8::Utf8ToWide(filename, wfilename))
   {
-    #pragma omp critical(stdio)
-    std::cerr << "Could not convert \"" << filename << "\" to a wide string." << std::endl;
+    LockedStream(std::cerr) << "Could not convert \"" << filename << "\" to a wide string." << std::endl;
     return 0;
   }
 
@@ -479,8 +462,7 @@ bool DiskFile::FileExists(std::string filename)
   std::wstring wfilename;
   if (!utf8::Utf8ToWide(filename, wfilename))
   {
-    #pragma omp critical(stdio)
-    std::cerr << "Could not convert \"" << filename << "\" to a wide string." << std::endl;
+    LockedStream(std::cerr) << "Could not convert \"" << filename << "\" to a wide string." << std::endl;
     return false;
   }
 
@@ -544,8 +526,7 @@ bool DiskFile::CreateParentDirectory(std::string _pathname)
 
     if (mkdir(path.c_str(), S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH))
     {
-      #pragma omp critical(stdio)
-      *serr << "Could not create the " << path << " directory: " << strerror(errno) << std::endl;
+      LockedStream(*serr) << "Could not create the " << path << " directory: " << strerror(errno) << std::endl;
       return false;
     }
   }
@@ -566,16 +547,14 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
 
   if (_filesize > (u64)MaxOffset)
   {
-    #pragma omp critical(stdio)
-    *serr << "Requested file size for " << _filename << " is too large." << std::endl;
+    LockedStream(*serr) << "Requested file size for " << _filename << " is too large." << std::endl;
     return false;
   }
 
   int fd = open(_filename.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
   if (fd < 0)
   {
-    #pragma omp critical(stdio)
-    *serr << "Could not create " << _filename << ": " << strerror(errno) << std::endl;
+    LockedStream(*serr) << "Could not create " << _filename << ": " << strerror(errno) << std::endl;
 
     return false;
   }
@@ -588,8 +567,7 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
     ::remove(filename.c_str());
     errno = savederrno;
 
-    #pragma omp critical(stdio)
-    *serr << "Could not create " << _filename << ": " << strerror(errno) << std::endl;
+    LockedStream(*serr) << "Could not create " << _filename << ": " << strerror(errno) << std::endl;
 
     return false;
   }
@@ -598,8 +576,7 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
   {
     if (fseek(file, (OffsetType)_filesize-1, SEEK_SET))
     {
-      #pragma omp critical(stdio)
-      *serr << "Could not set end of file of " << _filename << ": " << strerror(errno) << std::endl;
+      LockedStream(*serr) << "Could not set end of file of " << _filename << ": " << strerror(errno) << std::endl;
 
       fclose(file);
       file = 0;
@@ -609,8 +586,7 @@ bool DiskFile::Create(std::string _filename, u64 _filesize)
 
     if (1 != fwrite(&_filesize, 1, 1, file))
     {
-      #pragma omp critical(stdio)
-      *serr << "Could not set end of file of " << _filename << ": " << strerror(errno) << std::endl;
+      LockedStream(*serr) << "Could not set end of file of " << _filename << ": " << strerror(errno) << std::endl;
 
       fclose(file);
       file = 0;
@@ -635,16 +611,14 @@ bool DiskFile::Write(u64 _offset, const void *buffer, size_t length, LengthType 
   {
     if (_offset > (u64)MaxOffset)
     {
-        #pragma omp critical(stdio)
-        *serr << "Could not write " << (u64)length << " bytes to " << filename << " at offset " << _offset << std::endl;
+        LockedStream(*serr) << "Could not write " << (u64)length << " bytes to " << filename << " at offset " << _offset << std::endl;
       return false;
     }
 
 
     if (fseek(file, (OffsetType)_offset, SEEK_SET))
     {
-      #pragma omp critical(stdio)
-      *serr << "Could not write " << (u64)length << " bytes to " << filename << " at offset " << _offset << ": " << strerror(errno) << std::endl;
+      LockedStream(*serr) << "Could not write " << (u64)length << " bytes to " << filename << " at offset " << _offset << ": " << strerror(errno) << std::endl;
       return false;
     }
     offset = _offset;
@@ -661,8 +635,7 @@ bool DiskFile::Write(u64 _offset, const void *buffer, size_t length, LengthType 
     LengthType wrote = fwrite(buffer, 1, write, file);
     if (wrote != write)
     {
-      #pragma omp critical(stdio)
-      *serr << "Could not write " << (u64)length << " bytes to " << filename << " at offset " << _offset << ": " << strerror(errno) << std::endl;
+      LockedStream(*serr) << "Could not write " << (u64)length << " bytes to " << filename << " at offset " << _offset << ": " << strerror(errno) << std::endl;
       return false;
     }
 
@@ -690,8 +663,7 @@ bool DiskFile::Open(const std::string &_filename, u64 _filesize)
 
   if (_filesize > (u64)MaxOffset)
   {
-    #pragma omp critical(stdio)
-    *serr << "File size for " << _filename << " is too large." << std::endl;
+    LockedStream(*serr) << "File size for " << _filename << " is too large." << std::endl;
     return false;
   }
 
@@ -715,8 +687,7 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxleng
 
   if (_offset > (u64)MaxOffset)
   {
-    #pragma omp critical(stdio)
-    *serr << "Could not read " << (u64)length << " bytes from " << filename << " at offset " << _offset << std::endl;
+    LockedStream(*serr) << "Could not read " << (u64)length << " bytes from " << filename << " at offset " << _offset << std::endl;
     return false;
   }
 
@@ -735,8 +706,7 @@ bool DiskFile::Read(u64 _offset, void *buffer, size_t length, LengthType maxleng
     {
       // NOTE: This can happen on error or when hitting the end-of-file.
 
-      #pragma omp critical(stdio)
-      *serr << "Could not read " << (u64)length << " bytes from " << filename << " at offset " << _offset << ": " << strerror(errno) << std::endl;
+      LockedStream(*serr) << "Could not read " << (u64)length << " bytes from " << filename << " at offset " << _offset << ": " << strerror(errno) << std::endl;
       return false;
     }
 
@@ -1038,8 +1008,7 @@ bool DiskFile::Delete(void)
 #endif
   else
   {
-    #pragma omp critical(stdio)
-    *serr << "Cannot delete " << filename << std::endl;
+    LockedStream(*serr) << "Cannot delete " << filename << std::endl;
 
     return false;
   }
@@ -1099,15 +1068,13 @@ bool DiskFile::Rename(void)
     // Check path length against maximum
     if (newname.length() > _MAX_PATH)
     {
-      #pragma omp critical(stdio)
-      *serr << filename << " pathlength is more than " << _MAX_PATH << "." << std::endl;
+      LockedStream(*serr) << filename << " pathlength is more than " << _MAX_PATH << "." << std::endl;
       return false;
     }
 
     if (!utf8::Utf8ToWide(newname, wnewname))
     {
-      #pragma omp critical(stdio)
-      *serr << "Could not convert \"" << newname << "\" to a wide string." << std::endl;
+      LockedStream(*serr) << "Could not convert \"" << newname << "\" to a wide string." << std::endl;
       return false;
     }
 
@@ -1131,8 +1098,7 @@ bool DiskFile::Rename(void)
     // Check path length against maximum
     if (newname.length() > _MAX_PATH)
     {
-      #pragma omp critical(stdio)
-      *serr << filename << " pathlength is more than " << _MAX_PATH << "." << std::endl;
+      LockedStream(*serr) << filename << " pathlength is more than " << _MAX_PATH << "." << std::endl;
       return false;
     }
   } while (stat(newname.c_str(), &st) == 0);
@@ -1181,8 +1147,7 @@ bool DiskFile::Rename(std::string _filename)
     return true;
   }
 
-  #pragma omp critical(stdio)
-  *serr << filename << " cannot be renamed to " << _filename << std::endl;
+  LockedStream(*serr) << filename << " cannot be renamed to " << _filename << std::endl;
 
   return false;
 }
@@ -1198,8 +1163,7 @@ bool DiskFile::Rename(std::string _filename)
     return true;
   }
 
-  #pragma omp critical(stdio)
-  *serr << filename << " cannot be renamed to " << _filename << std::endl;
+  LockedStream(*serr) << filename << " cannot be renamed to " << _filename << std::endl;
 
   return false;
 }

--- a/src/libpar2internal.h
+++ b/src/libpar2internal.h
@@ -193,8 +193,45 @@ typedef unsigned int     size_t;
 
 #include <ctype.h>
 #include <iomanip>
+#include <atomic>
+#include <mutex>
 
 #include <cassert>
+
+// Holds a lock for the duration of one output statement, so that lines written
+// from several threads do not interleave.
+class LockedStream
+{
+public:
+  explicit LockedStream(std::ostream &stream)
+    : stream(stream)
+    , lock(Mutex())
+  {
+  }
+
+  template<typename T>
+  LockedStream& operator<<(const T &value)
+  {
+    stream << value;
+    return *this;
+  }
+
+  LockedStream& operator<<(std::ostream& (*manipulator)(std::ostream&))
+  {
+    stream << manipulator;
+    return *this;
+  }
+
+private:
+  static std::mutex& Mutex(void)
+  {
+    static std::mutex mutex;
+    return mutex;
+  }
+
+  std::ostream &stream;
+  std::lock_guard<std::mutex> lock;
+};
 
 #ifdef offsetof
 #undef offsetof

--- a/src/par2creator.cpp
+++ b/src/par2creator.cpp
@@ -372,8 +372,7 @@ bool Par2Creator::OpenSourceFiles(const std::vector<std::string> &extrafiles, st
 
     if (noiselevel > nlSilent)
     {
-      #pragma omp critical(stdio)
-      sout << "Opening: " << name << std::endl;
+      LockedStream(sout) << "Opening: " << name << std::endl;
     }
 
     // Open the source file and compute its Hashes and CRCs.
@@ -394,8 +393,8 @@ bool Par2Creator::OpenSourceFiles(const std::vector<std::string> &extrafiles, st
 
     // Record the file verification and file description packets
     // in the critical packet list.
-    #pragma omp critical
     {
+    std::lock_guard<std::mutex> lock(sourcefilesMutex);
     sourcefile->RecordCriticalPackets(criticalpackets);
 
     // Add the source file to the sourcefiles array.

--- a/src/par2creator.h
+++ b/src/par2creator.h
@@ -143,6 +143,8 @@ protected:
   std::vector<Par2CreatorSourceFile*> sourcefiles;  // Array containing details of the source files
                                                // as well as the file verification and file
                                                // description packets for them.
+  std::mutex                      sourcefilesMutex; // Guards sourcefiles and criticalpackets while
+                                                    // the source files are opened in parallel.
 
   std::vector<DataBlock>          sourceblocks;     // Array with one entry for every source block.
 

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -1250,8 +1250,7 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
 
     if (noiselevel >= nlDebug)
     {
-      #pragma omp critical(stdio)
-      sout << "[DEBUG] VerifySourceFiles ----\n"
+      LockedStream(sout) << "[DEBUG] VerifySourceFiles ----\n"
         "[DEBUG] file: " << file << "\n"
         "[DEBUG] name: " << name << "\n"
         "[DEBUG] targ: " << target_pathname << std::endl;
@@ -1259,8 +1258,8 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
 
     // if the target file is in the list of extra files, we remove it
     // from the extra files.
-    #pragma omp critical(extrafiles)
     {
+      std::lock_guard<std::mutex> lock(extraFilesMutex);
       std::vector<std::string>::iterator it = extrafiles.begin();
       for (; it != extrafiles.end(); ++it)
       {
@@ -1276,13 +1275,14 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
 
     // Check to see if we have already used this file
     bool b;
-    #pragma omp critical(diskFileMap)
-    b = diskFileMap.Find(file) != 0;
+    {
+      std::lock_guard<std::mutex> lock(diskFileMapMutex);
+      b = diskFileMap.Find(file) != 0;
+    }
     if (b)
     {
       // The file has already been used!
-      #pragma omp critical(stdio)
-      serr << "Source file " << name << " is a duplicate." << std::endl;
+      LockedStream(serr) << "Source file " << name << " is a duplicate." << std::endl;
 
       finalresult = false;
     }
@@ -1301,8 +1301,10 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
 
         // Remember that we have processed this file
         bool success;
-        #pragma omp critical(diskFileMap)
-        success = diskFileMap.Insert(diskfile);
+        {
+          std::lock_guard<std::mutex> lock(diskFileMapMutex);
+          success = diskFileMap.Insert(diskfile);
+        }
         assert(success);
         // Do the actual verification
         if (!VerifyDataFile(diskfile, sourcefile, basepath MT_PROGRESS))
@@ -1318,8 +1320,7 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
 
         if (noiselevel > nlSilent)
         {
-          #pragma omp critical(stdio)
-          sout << "Target: \"" << name << "\" - missing." << std::endl;
+          LockedStream(sout) << "Target: \"" << name << "\" - missing." << std::endl;
         }
       }
     }
@@ -1360,8 +1361,10 @@ bool Par2Repairer::VerifyExtraFiles(const std::vector<std::string> &extrafiles, 
 
         // Has this file already been dealt with
         bool b;
-        #pragma omp critical(diskFileMap)
-        b = diskFileMap.Find(filename) == 0;
+        {
+          std::lock_guard<std::mutex> lock(diskFileMapMutex);
+          b = diskFileMap.Find(filename) == 0;
+        }
         if (b)
         {
           DiskFile *diskfile = new DiskFile(sout, serr);
@@ -1375,8 +1378,10 @@ bool Par2Repairer::VerifyExtraFiles(const std::vector<std::string> &extrafiles, 
 
           // Remember that we have processed this file
           bool success;
-          #pragma omp critical(diskFileMap)
-          success = diskFileMap.Insert(diskfile);
+          {
+            std::lock_guard<std::mutex> lock(diskFileMapMutex);
+            success = diskFileMap.Insert(diskfile);
+          }
           assert(success);
 
           // Do the actual verification
@@ -1533,8 +1538,7 @@ bool Par2Repairer::VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *so
       {
         if (noiselevel > nlSilent)
         {
-          #pragma omp critical(stdio)
-          sout << diskfile->FileName() << " is a perfect match for " << sourcefile->GetDescriptionPacket()->FileName() << std::endl;
+          LockedStream(sout) << diskfile->FileName() << " is a perfect match for " << sourcefile->GetDescriptionPacket()->FileName() << std::endl;
         }
         // Record that we have a perfect match for this source file
         sourcefile->SetCompleteFile(diskfile);
@@ -1751,13 +1755,11 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
     {
       if (originalsourcefile != 0)
       {
-        #pragma omp critical(stdio)
-        sout << "Target: \"" << name << "\" - empty." << std::endl;
+        LockedStream(sout) << "Target: \"" << name << "\" - empty." << std::endl;
       }
       else
       {
-        #pragma omp critical(stdio)
-        sout << "File: \"" << name << "\" - empty." << std::endl;
+        LockedStream(sout) << "File: \"" << name << "\" - empty." << std::endl;
       }
     }
 
@@ -1777,8 +1779,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
 #ifdef _OPENMP
   if (noiselevel > nlQuiet)
   {
-    #pragma omp critical(stdio)
-    sout << "Opening: \"" << shortname << "\"" << std::endl;
+    LockedStream(sout) << "Opening: \"" << shortname << "\"" << std::endl;
   }
 #else
   std::string message = "Scanning: \"";
@@ -2122,8 +2123,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
           // Were we scanning the target file or an extra file
           if (originalsourcefile != 0)
           {
-            #pragma omp critical(stdio)
-            sout << "Target: \""
+            LockedStream(sout) << "Target: \""
               << name
               << "\" - damaged, found "
               << count
@@ -2132,8 +2132,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
           }
           else
           {
-            #pragma omp critical(stdio)
-            sout << "File: \""
+            LockedStream(sout) << "File: \""
               << name
               << "\" - found "
               << count
@@ -2146,8 +2145,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
           // Did we find data blocks that belong to the target file
           if (originalsourcefile == sourcefile)
           {
-            #pragma omp critical(stdio)
-            sout << "Target: \""
+            LockedStream(sout) << "Target: \""
               << name
               << "\" - damaged. Found "
               << count
@@ -2162,8 +2160,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
             std::string targetname;
             DiskFile::SplitRelativeFilename(sourcefile->TargetFileName(), basepath, targetname);
 
-            #pragma omp critical(stdio)
-            sout << "Target: \""
+            LockedStream(sout) << "Target: \""
               << name
               << "\" - damaged. Found "
               << count
@@ -2179,8 +2176,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
             std::string targetname;
             DiskFile::SplitRelativeFilename(sourcefile->TargetFileName(), basepath, targetname);
 
-            #pragma omp critical(stdio)
-            sout << "File: \""
+            LockedStream(sout) << "File: \""
               << name
               << "\" - found "
               << count
@@ -2195,8 +2191,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
 
         if (skippeddata > 0)
         {
-          #pragma omp critical(stdio)
-          sout << skippeddata << " bytes of data were skipped whilst scanning.\n"
+          LockedStream(sout) << skippeddata << " bytes of data were skipped whilst scanning.\n"
             "If there are not enough blocks found to repair: try again "
             "with the -N option." << std::endl;
         }
@@ -2209,8 +2204,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
         // Did we match the target file
         if (originalsourcefile == sourcefile)
         {
-          #pragma omp critical(stdio)
-          sout << "Target: \"" << name << "\" - found." << std::endl;
+          LockedStream(sout) << "Target: \"" << name << "\" - found." << std::endl;
         }
         // Were we scanning the target file or an extra file
         else if (originalsourcefile != 0)
@@ -2218,8 +2212,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
           std::string targetname;
           DiskFile::SplitRelativeFilename(sourcefile->TargetFileName(), basepath, targetname);
 
-          #pragma omp critical(stdio)
-          sout << "Target: \""
+          LockedStream(sout) << "Target: \""
             << name
             << "\" - is a match for \""
             << targetname
@@ -2231,8 +2224,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
           std::string targetname;
           DiskFile::SplitRelativeFilename(sourcefile->TargetFileName(), basepath, targetname);
 
-          #pragma omp critical(stdio)
-          sout << "File: \""
+          LockedStream(sout) << "File: \""
             << name
             << "\" - is a match for \""
             << targetname
@@ -2252,8 +2244,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
       // had already found in other files.
       if (duplicatecount > 0)
       {
-        #pragma omp critical(stdio)
-        sout << "File: \""
+        LockedStream(sout) << "File: \""
           << name
           << "\" - found "
           << duplicatecount
@@ -2262,8 +2253,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
       }
       else
       {
-        #pragma omp critical(stdio)
-        sout << "File: \""
+        LockedStream(sout) << "File: \""
           << name
           << "\" - no data found."
           << std::endl;
@@ -2271,8 +2261,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
 
       if (skippeddata > 0)
       {
-        #pragma omp critical(stdio)
-        sout << skippeddata << " bytes of data were skipped whilst scanning.\n"
+        LockedStream(sout) << skippeddata << " bytes of data were skipped whilst scanning.\n"
           "If there are not enough blocks found to repair: try again "
           "with the -N option." << std::endl;
       }

--- a/src/par2repairer.h
+++ b/src/par2repairer.h
@@ -195,6 +195,8 @@ protected:
   CreatorPacket            *creatorpacket;           // One copy of the creator packet.
 
   DiskFileMap               diskFileMap;
+  std::mutex                diskFileMapMutex;        // Guards diskFileMap while files are verified in parallel.
+  std::mutex                extraFilesMutex;         // Guards the caller's list of extra files.
 
   std::map<MD5Hash,Par2RepairerSourceFile*> sourcefilemap;// Map from FileId to SourceFile
   std::vector<Par2RepairerSourceFile*>      sourcefiles;  // The source files

--- a/src/progressmeter.h
+++ b/src/progressmeter.h
@@ -31,8 +31,8 @@ class ProgressMeter
   std::ostream &sout;        // stream for output (for commandline, this is cout)
   const std::string message; // message to display alongside percentage
   const float scale;         // pre-computed multiplier to convert progress value into a percentage*10
-  TValue current;            // last known progress value
-  steady_clock::duration::rep printed; // last time progress was outputted
+  std::atomic<TValue> current; // last known progress value
+  std::atomic<steady_clock::duration::rep> printed; // last time progress was outputted
 
   inline u32 CalcThousandths(TValue val) const
   {
@@ -46,11 +46,7 @@ class ProgressMeter
       return false;
 
     // check if enough time has passed
-    steady_clock::duration::rep lastprinted;
-#if defined(_OPENMP) && _OPENMP >= 201107
-    #pragma omp atomic read
-#endif
-    lastprinted = printed;
+    steady_clock::duration::rep lastprinted = printed.load(std::memory_order_relaxed);
     
     steady_clock::time_point now = steady_clock::now();
     steady_clock::time_point lastpoint = steady_clock::time_point(steady_clock::duration(lastprinted));
@@ -59,10 +55,7 @@ class ProgressMeter
     if (now - lastpoint >= PRINT_INTERVAL || newfraction == 1000)
     {
       LockedStream(sout) << message << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
-#if defined(_OPENMP) && _OPENMP >= 201107
-      #pragma omp atomic write
-#endif
-      printed = now.time_since_epoch().count();
+      printed.store(now.time_since_epoch().count(), std::memory_order_relaxed);
       return true;
     }
     return false;
@@ -77,41 +70,20 @@ public:
   // NOTE: Update() doesn't always update current value, so don't mix it with Add()
   void Update(TValue newval)
   {
-    TValue oldval;
-#if defined(_OPENMP) && _OPENMP >= 201107
-    #pragma omp atomic read
-#endif
-    oldval = current;
+    TValue oldval = current.load(std::memory_order_relaxed);
     if (PrintFraction(oldval, newval))
-    {
-#if defined(_OPENMP) && _OPENMP >= 201107
-      #pragma omp atomic write
-#endif
-      current = newval;
-    }
+      current.store(newval, std::memory_order_relaxed);
   }
   void Add(TValue amount)
   {
-    TValue newval;
-#if defined(_OPENMP) && _OPENMP >= 201107
-    #pragma omp atomic capture
-    newval = current += amount;
-#else
-    newval = current + amount;
-    #pragma omp atomic
-    current += amount;
-#endif
+    TValue newval = current.fetch_add(amount, std::memory_order_relaxed) + amount;
     PrintFraction(newval - amount, newval);
   }
 
   // print a line whilst progress is still running
   void PrintLine(const std::string &line)
   {
-    TValue val;
-#if defined(_OPENMP) && _OPENMP >= 201107
-    #pragma omp atomic read
-#endif
-    val = current;
+    TValue val = current.load(std::memory_order_relaxed);
     u32 fraction = CalcThousandths(val);
     LockedStream(sout) << std::setw(message.size()+7) << std::setfill(' ') << "\r"
       << line << '\n'

--- a/src/progressmeter.h
+++ b/src/progressmeter.h
@@ -58,8 +58,7 @@ class ProgressMeter
     // if enough time has passed, print the current progress, and update the time record
     if (now - lastpoint >= PRINT_INTERVAL || newfraction == 1000)
     {
-      #pragma omp critical(stdio)
-      sout << message << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
+      LockedStream(sout) << message << newfraction/10 << '.' << newfraction%10 << "%\r" << std::flush;
 #if defined(_OPENMP) && _OPENMP >= 201107
       #pragma omp atomic write
 #endif
@@ -114,8 +113,7 @@ public:
 #endif
     val = current;
     u32 fraction = CalcThousandths(val);
-    #pragma omp critical(stdio)
-    sout << std::setw(message.size()+7) << std::setfill(' ') << "\r"
+    LockedStream(sout) << std::setw(message.size()+7) << std::setfill(' ') << "\r"
       << line << '\n'
       << message << fraction/10 << '.' << fraction%10 << "%\r" << std::flush;
   }


### PR DESCRIPTION
First step of the std::thread item in ROADMAP. No threading change but replaces most `pragma omp`.

Critical sections replaced with locks. `critical(stdio)` becomes a `LockedStream` holding a mutex for the duration of one output statement, so the guarded sites stay one-liners. The rest are `diskFileMap`, `extrafiles` and one unnamed, all plain `std::mutex` members.

The seven `atomic` pragmas in progressmeter.h become `std::atomic`

`ProgressMeter<u64>` means 64-bit atomics, so configure now probes for `-latomic`. x86_64 and MSVC never need it, so CI will not catch its absence; 32-bit ARM and i386 do.
