### PR TITLE
Scan a file's blocks on a thread pool fed by a reader thread

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -59,10 +59,11 @@ par2_SOURCES = src/par2cmdline.cpp \
 par2_LDADD = libpar2.a
 
 LDADD = -lstdc++
-AM_CXXFLAGS = -Wall -std=c++14 $(OPENMP_CXXFLAGS)
+AM_CXXFLAGS = -Wall -std=c++14 $(OPENMP_CXXFLAGS) $(PTHREAD_FLAGS)
+AM_LDFLAGS = $(PTHREAD_FLAGS)
 
 if MINGW
-par2_LDFLAGS = -municode
+par2_LDFLAGS = $(AM_LDFLAGS) -municode
 endif
 
 EXTRA_DIST = \

--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,25 @@ AC_FUNC_FSEEKO
 dnl Check for OpenMP
 AC_OPENMP
 
+dnl std::thread needs pthreads where they are not already part of libc.
+AC_SEARCH_LIBS([pthread_create], [pthread])
+
+dnl -pthread is what tells the compiler and the linker that a build is
+dnl threaded. AC_SEARCH_LIBS above only covers the library.
+AC_MSG_CHECKING([whether $CXX accepts -pthread])
+par2_saved_CXXFLAGS=$CXXFLAGS
+CXXFLAGS="$CXXFLAGS -pthread"
+AC_LINK_IFELSE([AC_LANG_PROGRAM(
+  [[#include <thread>
+    static void par2_probe(void) {}]],
+  [[std::thread thread(par2_probe); thread.join();]])],
+  [AC_MSG_RESULT([yes])
+   PTHREAD_FLAGS="-pthread"],
+  [AC_MSG_RESULT([no])
+   PTHREAD_FLAGS=""])
+CXXFLAGS=$par2_saved_CXXFLAGS
+AC_SUBST([PTHREAD_FLAGS])
+
 dnl ProgressMeter keeps 64-bit counters in std::atomic. Most targets emit those
 dnl inline, but 32-bit ones generally need libatomic to supply them.
 AC_MSG_CHECKING([whether 64-bit atomics need libatomic])

--- a/src/libpar2internal.h
+++ b/src/libpar2internal.h
@@ -194,7 +194,9 @@ typedef unsigned int     size_t;
 #include <ctype.h>
 #include <iomanip>
 #include <atomic>
+#include <condition_variable>
 #include <mutex>
+#include <thread>
 
 #include <cassert>
 

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -1628,7 +1628,7 @@ bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [i
   buffer[0].resize((size_t)batchblocks * blocksize);
   buffer[1].resize((size_t)batchblocks * blocksize);
 
-  bool readfailed = false;
+  std::atomic<bool> readfailed(false);
 
   FileHasher filehasher(fullhash);
 
@@ -1638,9 +1638,9 @@ bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [i
   auto readbatch = [&](u32 firstblock, std::vector<char> &into)
   {
     const u32 blocks = std::min(firstblock + batchblocks, blockcount) - firstblock;
-    const u64 offset = (u64)firstblock * blocksize;
-    const size_t span = (size_t)blocks * blocksize;
-    const size_t length = (size_t)std::min((u64)span, filesize - offset);
+    const u64 offset = static_cast<u64>(firstblock) * blocksize;
+    const size_t span = static_cast<size_t>(blocks) * blocksize;
+    const size_t length = std::min(static_cast<u64>(span), filesize - offset);
 
     if (!diskfile->Read(offset, &into[0], length))
     {
@@ -1654,52 +1654,112 @@ bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [i
       memset(&into[length], 0, span - length);
   };
 
-  readbatch(0, buffer[0]);
-
-  #pragma omp parallel num_threads(workers)
+  auto checkblock = [&](const u32 block, const std::vector<char> &checking, u32 firstblock)
   {
-    for (u32 firstblock=0; firstblock<blockcount && !readfailed; firstblock+=batchblocks)
+    const u64 length = std::min(blocksize, filesize - static_cast<u64>(block) * blocksize);
+    const char *at = &checking[static_cast<size_t>(block - firstblock) * blocksize];
+    const FILEVERIFICATIONENTRY *entry = verificationpacket->VerificationEntry(block);
+
+    const u32 checksum = ~0 ^ CRCUpdateBlock(~0, blocksize, at);
+    if (checksum != entry->crc)
+      return;
+
+    MD5Context context;
+    context.Update(at, blocksize);
+
+    MD5Hash hash{};
+    context.Final(hash);
+
+    if (hash != entry->hash)
+      return;
+
+    matched[block] = 1;
+
+    if (noiselevel > nlQuiet)
+      progress.Add(length);
+  };
+
+  // Checkers take the blocks of a batch claimblocks at a time. One block each
+  // is what the batch holds today; a hasher that takes several blocks at once
+  // would ask for more.
+  const u32 claimblocks = 1;
+  const u32 batchcount = (blockcount + batchblocks - 1) / batchblocks;
+
+  std::mutex mutex;
+  std::condition_variable batchfilled;   // the reader has filled a buffer
+  std::condition_variable batchchecked;  // the checkers have emptied one
+  u32 filledbatches = 0;                 // batches the reader has completed
+  u32 outstanding[2] = { 0, 0 };         // blocks left to check in each buffer
+  std::atomic<u32> nextblock(0);      // the next block a checker may claim
+
+  // Reads each batch into the buffer the checkers are not using, so that the
+  // next batch arrives while the current one is being hashed
+  std::thread reader([&] {
+    for (u32 batch = 0; batch < batchcount; ++batch)
     {
-      const u32 lastblock = std::min(firstblock + batchblocks, blockcount);
-      const u32 batch = firstblock / batchblocks;
+      const u32 firstblock = batch * batchblocks;
+      const u32 blocks = std::min(firstblock + batchblocks, blockcount) - firstblock;
 
-      std::vector<char> &checking = buffer[batch % 2];
-      std::vector<char> &reading = buffer[(batch + 1) % 2];
-
-      // Reads the next block while this one is being hashed
-      #pragma omp single nowait
       {
-        if (lastblock < blockcount)
-          readbatch(lastblock, reading);
+        std::unique_lock<std::mutex> lock(mutex);
+        batchchecked.wait(lock, [&]{ return outstanding[batch % 2] == 0; });
       }
 
-      #pragma omp for schedule(dynamic)
-      for (int b=(int)firstblock; b<(int)lastblock; ++b)
+      readbatch(firstblock, buffer[batch % 2]);
+
       {
-        const u64 length = std::min(blocksize, filesize - (u64)b * blocksize);
-        const char *at = &checking[(size_t)(b - (int)firstblock) * blocksize];
-        const FILEVERIFICATIONENTRY *entry = verificationpacket->VerificationEntry(b);
-
-        const u32 checksum = ~0 ^ CRCUpdateBlock(~0, (size_t)blocksize, at);
-        if (checksum != entry->crc)
-          continue;
-
-        MD5Context context;
-        context.Update(at, (size_t)blocksize);
-
-        MD5Hash hash;
-        context.Final(hash);
-
-        if (!(hash == entry->hash))
-          continue;
-
-        matched[b] = 1;
-
-        if (noiselevel > nlQuiet)
-          progress.Add(length);
+        std::lock_guard<std::mutex> lock(mutex);
+        outstanding[batch % 2] = blocks;
+        filledbatches = batch + 1;
       }
+      batchfilled.notify_all();
+
+      if (readfailed)
+        return;
     }
+  });
+
+  std::vector<std::thread> checkers;
+  checkers.reserve(workers);
+  for (u32 worker = 0; worker < workers; ++worker)
+  {
+    checkers.emplace_back([&]()
+    {
+      for (;;)
+      {
+        const u32 firstclaimed = nextblock.fetch_add(claimblocks);
+        if (firstclaimed >= blockcount)
+          return;
+
+        // A claim never spans two batches, because each batch sits in its own buffer
+        const u32 batch = firstclaimed / batchblocks;
+        const u32 lastclaimed = std::min(firstclaimed + claimblocks,
+                                         std::min((batch + 1) * batchblocks, blockcount));
+
+        {
+          std::unique_lock<std::mutex> lock(mutex);
+          batchfilled.wait(lock, [&]{ return filledbatches > batch || readfailed; });
+        }
+
+        if (readfailed)
+          return;
+
+        for (u32 block = firstclaimed; block < lastclaimed; ++block)
+          checkblock(block, buffer[batch % 2], batch * batchblocks);
+
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          outstanding[batch % 2] -= lastclaimed - firstclaimed;
+          if (outstanding[batch % 2] == 0)
+            batchchecked.notify_one();
+        }
+      }
+    });
   }
+
+  reader.join();
+  for (auto & checker : checkers)
+    checker.join();
 
   if (readfailed)
     return false;


### PR DESCRIPTION
The aligned block scan is the one parallel region that cannot be taken from par2cmdline-turbo. It runs a persistent team where `single nowait` reads the next batch while `for schedule(dynamic)` hashes the current one, so the double buffering is implicit in an OpenMP barrier.

This makes it explicit: a reader thread filling a free buffer, a pool of checkers draining the other, two condition variables and no barrier. Makefile.am pins -std=c++14, so std::barrier is not an option in any case.

Checkers claim a range of blocks rather than a single index. The range is 1, so scheduling is unchanged; it is a range because contiguous claims read better and leave room for a hasher that wants consecutive blocks.

std::thread needs pthreads on some toolchains, so configure gains AC_SEARCH_LIBS.