### PR TITLE
Replace the remaining OpenMP loops with std::thread and drop OpenMP

### DIFF
--- a/.github/workflows/build-check-valgrind.yml
+++ b/.github/workflows/build-check-valgrind.yml
@@ -22,8 +22,7 @@ jobs:
     # Runs tests
     # The shell scripts use the PARVALGRINDOPTS env var when set.
     #
-    # The suppressions file silences known false positives from the libgomp
-    # (OpenMP) thread pool
+    # The suppressions file silences known false positives
     - name: Run tests under valgrind
       env:
         PARVALGRINDOPTS: --leak-check=full --error-exitcode=1 --errors-for-leak-kinds=all --quiet --suppressions=${{ github.workspace }}/valgrind.supp

--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,7 @@ libpar2_a_SOURCES = src/crc.cpp src/crc.h \
 	src/par2fileformat.cpp src/par2fileformat.h \
 	src/par2repairer.cpp src/par2repairer.h \
 	src/par2repairersourcefile.cpp src/par2repairersourcefile.h \
+	src/foreach_parallel.h \
 	src/progressmeter.h \
 	src/recoverypacket.cpp src/recoverypacket.h \
 	src/reedsolomon.cpp src/reedsolomon.h \
@@ -59,7 +60,7 @@ par2_SOURCES = src/par2cmdline.cpp \
 par2_LDADD = libpar2.a
 
 LDADD = -lstdc++
-AM_CXXFLAGS = -Wall -std=c++14 $(OPENMP_CXXFLAGS) $(PTHREAD_FLAGS)
+AM_CXXFLAGS = -Wall -std=c++14 $(PTHREAD_FLAGS)
 AM_LDFLAGS = $(PTHREAD_FLAGS)
 
 if MINGW
@@ -198,7 +199,7 @@ EXTRA_DIST = \
 
 # Programs that need to be compiled for the test suite.
 # These are the unit tests.
-check_PROGRAMS = tests/letype_test tests/crc_test tests/md5_test tests/diskfile_test tests/filechecksummer_test tests/libpar2_test tests/commandline_test tests/descriptionpacket_test tests/criticalpacket_test tests/reedsolomon_test tests/galois_test tests/utf8_test
+check_PROGRAMS = tests/letype_test tests/crc_test tests/md5_test tests/diskfile_test tests/filechecksummer_test tests/libpar2_test tests/commandline_test tests/descriptionpacket_test tests/criticalpacket_test tests/reedsolomon_test tests/galois_test tests/foreach_parallel_test tests/utf8_test
 
 tests_letype_test_SOURCES = src/letype_test.cpp src/letype.h
 
@@ -227,6 +228,9 @@ tests_criticalpacket_test_LDADD = libpar2.a
 tests_reedsolomon_test_SOURCES = src/reedsolomon_test.cpp src/reedsolomon.cpp src/reedsolomon.h
 
 tests_galois_test_SOURCES = src/galois_test.cpp src/galois.cpp src/galois.h
+
+tests_foreach_parallel_test_SOURCES = src/foreach_parallel_test.cpp src/foreach_parallel.h
+tests_foreach_parallel_test_LDADD = libpar2.a
 
 tests_utf8_test_SOURCES = src/utf8_test.cpp src/utf8.cpp src/utf8.h
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,7 @@ To compile on Linux and other Unix variants use the following commands:
 
 For FreeBSD you must install the following dependencies:
 
-    pkg install git automake openmp
-
-OpenMP will only be available for 64bit systems in FreeBSD.
-
-For macOS you can install llvm via homebrew to get OpenMP support.
+    pkg install git automake
 
 See *INSTALL* for full details on how to use the *configure* script.
 

--- a/configure.ac
+++ b/configure.ac
@@ -60,9 +60,6 @@ AC_C_INLINE
 AC_SYS_LARGEFILE
 AC_FUNC_FSEEKO
 
-dnl Check for OpenMP
-AC_OPENMP
-
 dnl std::thread needs pthreads where they are not already part of libc.
 AC_SEARCH_LIBS([pthread_create], [pthread])
 

--- a/libpar2.vcxproj
+++ b/libpar2.vcxproj
@@ -103,6 +103,7 @@
     <ClInclude Include="src\par2fileformat.h" />
     <ClInclude Include="src\par2repairer.h" />
     <ClInclude Include="src\par2repairersourcefile.h" />
+    <ClInclude Include="src\foreach_parallel.h" />
     <ClInclude Include="src\progressmeter.h" />
     <ClInclude Include="src\recoverypacket.h" />
     <ClInclude Include="src\reedsolomon.h" />

--- a/libpar2.vcxproj.filters
+++ b/libpar2.vcxproj.filters
@@ -146,6 +146,9 @@
     <ClInclude Include="src\par2repairersourcefile.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\foreach_parallel.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="src\progressmeter.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/par2cmdline.props
+++ b/par2cmdline.props
@@ -15,7 +15,6 @@
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <OpenMPSupport>true</OpenMPSupport>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
@@ -40,7 +39,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <OpenMPSupport>true</OpenMPSupport>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/par2cmdline.sln
+++ b/par2cmdline.sln
@@ -32,6 +32,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "descriptionpacket_test", "t
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "criticalpacket_test", "tests\criticalpacket_test.vcxproj", "{862B6ABA-D1C6-4DB8-A893-747CC8B5D0F2}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "foreach_parallel_test", "tests\foreach_parallel_test.vcxproj", "{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -306,6 +308,24 @@ Global
 		{862B6ABA-D1C6-4DB8-A893-747CC8B5D0F2}.UnitTests-Release|Win32.Build.0 = Release|Win32
 		{862B6ABA-D1C6-4DB8-A893-747CC8B5D0F2}.UnitTests-Release|x64.ActiveCfg = Release|x64
 		{862B6ABA-D1C6-4DB8-A893-747CC8B5D0F2}.UnitTests-Release|x64.Build.0 = Release|x64
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.Debug|Win32.ActiveCfg = Debug|Win32
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.Debug|x64.ActiveCfg = Debug|x64
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.Release|ARM64.ActiveCfg = Release|ARM64
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.Release|Win32.ActiveCfg = Release|Win32
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.Release|x64.ActiveCfg = Release|x64
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.UnitTests-Debug|ARM64.ActiveCfg = Debug|ARM64
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.UnitTests-Debug|ARM64.Build.0 = Debug|ARM64
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.UnitTests-Debug|Win32.ActiveCfg = Debug|Win32
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.UnitTests-Debug|Win32.Build.0 = Debug|Win32
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.UnitTests-Debug|x64.ActiveCfg = Debug|x64
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.UnitTests-Debug|x64.Build.0 = Debug|x64
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.UnitTests-Release|ARM64.ActiveCfg = Release|ARM64
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.UnitTests-Release|ARM64.Build.0 = Release|ARM64
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.UnitTests-Release|Win32.ActiveCfg = Release|Win32
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.UnitTests-Release|Win32.Build.0 = Release|Win32
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.UnitTests-Release|x64.ActiveCfg = Release|x64
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.UnitTests-Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -323,6 +343,7 @@ Global
 		{E2E11769-76C3-40BD-BF1C-A9198481BD6E} = {09795456-9DA5-4253-AE04-DD2AB464238A}
 		{4E77EA22-B1FA-4FC0-8E13-74953DE245D7} = {09795456-9DA5-4253-AE04-DD2AB464238A}
 		{862B6ABA-D1C6-4DB8-A893-747CC8B5D0F2} = {09795456-9DA5-4253-AE04-DD2AB464238A}
+		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19} = {09795456-9DA5-4253-AE04-DD2AB464238A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {06E89BF8-F199-48B1-94CB-D7BB1B23DDD9}

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -22,6 +22,7 @@
 #include<iostream>
 #include<algorithm>
 #include "commandline.h"
+#include "foreach_parallel.h"
 #include <fstream>  //ADDED for @FILELIST FUNCTIONALY
 
 #ifdef _MSC_VER
@@ -34,10 +35,6 @@ static char THIS_FILE[]=__FILE__;
 #include <unistd.h>
 #endif
 
-// OpenMP
-#ifdef _OPENMP
-# include <omp.h>
-#endif
 
 CommandLine::CommandLine(void)
 : filesize_cache()
@@ -45,10 +42,8 @@ CommandLine::CommandLine(void)
 , noiselevel(nlUnknown)
 , memorylimit(0)
 , basepath()
-#ifdef _OPENMP
 , nthreads(0) // 0 means use default number
 , filethreads( _FILE_THREADS ) // default from header file
-#endif
 , parfilename()
 , rawfilenames()
 , extrafiles()
@@ -117,12 +112,10 @@ void CommandLine::usage(void)
     "  -v [-v]  : Be more verbose\n"
     "  -q [-q]  : Be more quiet (-q -q gives silence)\n"
     "  -m<n>    : Memory (in MB) to use (default is half of total physical memory)\n";
-#ifdef _OPENMP
   std::cout <<
-    "  -t<n>    : Number of threads used for main processing (" << omp_get_max_threads() << " detected)\n"
+    "  -t<n>    : Number of threads used for main processing (" << default_threads() << " detected)\n"
     "  -T<n>    : Number of files hashed in parallel\n"
     "             (" << _FILE_THREADS << " are the default)\n";
-#endif
   std::cout <<
     "  --       : Treat all following arguments as filenames\n"
     "Options: (verify or repair)\n"
@@ -405,7 +398,6 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
           }
           break;
 
-#ifdef _OPENMP
         case 't':  // Set amount of threads
           {
             nthreads = 0;
@@ -422,6 +414,9 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
               std::cerr << "Invalid thread option: " << argv[0] << std::endl;
               return false;
             }
+
+            if (nthreads > MAX_THREAD_COUNT)
+              nthreads = MAX_THREAD_COUNT;
           }
           break;
 
@@ -443,7 +438,6 @@ bool CommandLine::ReadArgs(int argc, const char * const *argv)
             }
           }
           break;
-#endif
 
         case 'r':  // Set the amount of redundancy required
           {

--- a/src/commandline.h
+++ b/src/commandline.h
@@ -100,10 +100,8 @@ public:
   bool                                GetSkipData(void) const    {return skipdata;}
   u64                                 GetSkipLeaway(void) const  {return skipleaway;}
   bool                                GetFullHash(void) const    {return fullhash;}
-#ifdef _OPENMP
   u32                                 GetNumThreads(void) {return nthreads;}
   u32                                 GetFileThreads(void) {return filethreads;}
-#endif
 
 
   static bool ComputeRecoveryBlockCount(u32 *recoveryblockcount,
@@ -147,12 +145,8 @@ protected:
                                // for the output buffer when creating
                                // or repairing.
   std::string basepath;             // the path par2 is run from
-#ifdef _OPENMP
   u32 nthreads;         // Default number of threads
   u32 filethreads;      // Number of threads for file processing
-#endif
-  // NOTE: using the "-t" option to set the number of threads does not
-  // end up here, but results in a direct call to "omp_set_num_threads"
 
   std::string parfilename;          // The name of the PAR2 file to create, or
                                // the name of the first PAR2 file to read

--- a/src/commandline_test.cpp
+++ b/src/commandline_test.cpp
@@ -557,10 +557,8 @@ int test10_helper(const char *arg,
 		  const NoiseLevel noiselevel,
 		  const size_t memorylimit,
 		  const std::string &basepath,
-#ifdef _OPENMP
 		  const u32 nthreads,
 		  const u32 filethreads,
-#endif
 		  const std::string &parfilename,
 		  const std::vector<std::string> &extrafiles,
 		  const u64 blocksize,
@@ -620,7 +618,6 @@ int test10_helper(const char *arg,
     std::cout << commandline.GetBasePath() << " != " << basepath << std::endl;
     return 1;
   }
-#ifdef _OPENMP
   if (commandline.GetNumThreads() != nthreads) {
     std::cout << "test10 fail nthreads  arg=" << arg << std::endl;
     std::cout << commandline.GetNumThreads() << " != " << nthreads << std::endl;
@@ -631,7 +628,6 @@ int test10_helper(const char *arg,
     std::cout << commandline.GetFileThreads() << " != " << filethreads << std::endl;
     return 1;
   }
-#endif
   if (commandline.GetParFilename() != parfilename) {
     std::cout << "test10 fail parfilename  arg=" << arg << std::endl;
     std::cout << commandline.GetParFilename() << " != " << parfilename << std::endl;
@@ -714,10 +710,8 @@ int test10() {
   const NoiseLevel default_noiselevel = nlNormal;
   const size_t default_memorylimit = commandline_for_defaults.GetMemoryLimit();
   const std::string &default_basepath = commandline_for_defaults.GetBasePath();
-#ifdef _OPENMP
   const u32 default_nthreads = 0;
   const u32 default_filethreads = _FILE_THREADS;
-#endif
   std::string default_parfilename = default_basepath + "foo";  // ".par2" is stripped.
   std::vector<std::string> default_extrafiles;
   default_extrafiles.push_back(default_basepath + "input1.txt");
@@ -732,10 +726,8 @@ int test10() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -754,10 +746,8 @@ int test10() {
 		    nlNoisy,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -773,10 +763,8 @@ int test10() {
 		    nlDebug,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -792,10 +780,8 @@ int test10() {
 		    nlQuiet,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -811,10 +797,8 @@ int test10() {
 		    nlSilent,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -830,10 +814,8 @@ int test10() {
 		    default_noiselevel,
 		    16*1024*1024,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -844,7 +826,6 @@ int test10() {
     return 1;
   }
 
-#ifdef _OPENMP
   // -t option
   if (test10_helper("par2 create -t42 foo.par2 input1.txt input2.txt",
 		    default_noiselevel,
@@ -878,17 +859,14 @@ int test10() {
 		    default_recoveryblockcount)) {
     return 1;
   }
-#endif
 
   // -- option
   if (test10_helper("par2 create -- foo.par2 input1.txt input2.txt",
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -902,10 +880,8 @@ int test10() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_basepath + "-foo",
 		    default_extrafiles,
 		    default_blocksize,
@@ -928,10 +904,8 @@ int test10() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    extrafiles,
 		    default_blocksize,
@@ -949,10 +923,8 @@ int test10() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -971,10 +943,8 @@ int test10() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    longestfilelen_rounded_up,
@@ -988,10 +958,8 @@ int test10() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    8,
@@ -1012,10 +980,8 @@ int test10() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -1049,10 +1015,8 @@ int test10() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -1066,10 +1030,8 @@ int test10() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -1083,10 +1045,8 @@ int test10() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -1100,10 +1060,8 @@ int test10() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -1117,10 +1075,8 @@ int test10() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -1134,10 +1090,8 @@ int test10() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    default_blocksize,
@@ -1166,10 +1120,8 @@ int test11_helper(const char *arg,
 		  const NoiseLevel noiselevel,
 		  const size_t memorylimit,
 		  const std::string &basepath,
-#ifdef _OPENMP
 		  const u32 nthreads,
 		  const u32 filethreads,
-#endif
 		  const std::string &parfilename,
 		  const std::vector<std::string> &extrafiles,
 		  const CommandLine::Version version,
@@ -1230,7 +1182,6 @@ int test11_helper(const char *arg,
     std::cout << commandline.GetBasePath() << " != " << basepath << std::endl;
     return 1;
   }
-#ifdef _OPENMP
   if (commandline.GetNumThreads() != nthreads) {
     std::cout << "test11 fail nthreads  arg=" << arg << std::endl;
     std::cout << commandline.GetNumThreads() << " != " << nthreads << std::endl;
@@ -1241,7 +1192,6 @@ int test11_helper(const char *arg,
     std::cout << commandline.GetFileThreads() << " != " << filethreads << std::endl;
     return 1;
   }
-#endif
   if (commandline.GetParFilename() != parfilename) {
     std::cout << "test11 fail parfilename  arg=" << arg << std::endl;
     std::cout << commandline.GetParFilename() << " != " << parfilename << std::endl;
@@ -1323,10 +1273,8 @@ int test11() {
   const NoiseLevel default_noiselevel = nlNormal;
   const size_t default_memorylimit = commandline_for_defaults.GetMemoryLimit();
   const std::string &default_basepath = commandline_for_defaults.GetBasePath();
-#ifdef _OPENMP
   const u32 default_nthreads = 0;
   const u32 default_filethreads = _FILE_THREADS;
-#endif
   std::string default_parfilename = "foo.par2"; // relative path, par2 is NOT stripped.
   std::vector<std::string> default_extrafiles;
   default_extrafiles.push_back(default_basepath + "input1.txt");
@@ -1339,10 +1287,8 @@ int test11() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1360,10 +1306,8 @@ int test11() {
 		    nlNoisy,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1377,10 +1321,8 @@ int test11() {
 		    nlNoisy,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1395,10 +1337,8 @@ int test11() {
 		    nlDebug,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1413,10 +1353,8 @@ int test11() {
 		    nlQuiet,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1431,10 +1369,8 @@ int test11() {
 		    nlSilent,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1449,10 +1385,8 @@ int test11() {
 		    default_noiselevel,
 		    16*1024*1024,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1462,7 +1396,6 @@ int test11() {
 		    default_skipleaway)) {
     return 1;
   }
-#ifdef _OPENMP
   // -t
   if (test11_helper("par2 repair -t42 foo.par2 input1.txt input2.txt",
 		    default_noiselevel,
@@ -1495,16 +1428,13 @@ int test11() {
 		    default_skipleaway)) {
     return 1;
   }
-#endif
   // --
   if (test11_helper("par2 repair -- foo.par2 input1.txt input2.txt",
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1524,10 +1454,8 @@ int test11() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    "-foo.par2",
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1554,10 +1482,8 @@ int test11() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    extrafiles,
 		    CommandLine::verPar2,
@@ -1576,10 +1502,8 @@ int test11() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1594,10 +1518,8 @@ int test11() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1612,10 +1534,8 @@ int test11() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1631,10 +1551,8 @@ int test11() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    default_parfilename,
 		    default_extrafiles,
 		    CommandLine::verPar2,
@@ -1659,10 +1577,8 @@ int test11() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    "bar.par",
 		    default_extrafiles,
 		    CommandLine::verPar1,
@@ -1676,10 +1592,8 @@ int test11() {
 		    default_noiselevel,
 		    default_memorylimit,
 		    default_basepath,
-#ifdef _OPENMP
 		    default_nthreads,
 		    default_filethreads,
-#endif
 		    "bar.par",
 		    default_extrafiles,
 		    CommandLine::verPar1,

--- a/src/foreach_parallel.h
+++ b/src/foreach_parallel.h
@@ -1,0 +1,250 @@
+//  This file is part of par2cmdline (a PAR 2.0 compatible file verification and
+//  repair tool). See http://parchive.sourceforge.net for details of PAR 2.0.
+//
+//  par2cmdline is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  par2cmdline is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef __FOREACH_PARALLEL_H__
+#define __FOREACH_PARALLEL_H__
+
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <exception>
+#include <mutex>
+#include <system_error>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+// The largest number of threads a requested thread count is taken up to. Each
+// thread costs a stack and a share of the buffers a loop divides between them.
+#define MAX_THREAD_COUNT 256
+
+// The number of threads to use when no particular number was asked for
+inline u32 default_threads(void)
+{
+  return std::max(1u, (u32)std::thread::hardware_concurrency());
+}
+
+// The number of threads to use for a requested count, where 0 asks for the
+// default
+inline u32 resolve_threads(const u32 requested)
+{
+  return requested != 0 ? std::min<u32>(requested, MAX_THREAD_COUNT) : default_threads();
+}
+
+// Runs a loop across a fixed set of threads which stay alive from one call to
+// the next, so that a loop entered many times pays for its threads once.
+class ParallelRunner
+{
+public:
+  // Runs on numthreads threads, one of which is the thread calling Run
+  explicit ParallelRunner(const u32 numthreads)
+  : threads()
+  , job(0)
+  , next(0)
+  , end(0)
+  , generation(0)
+  , outstanding(0)
+  , stopping(false)
+  , mutex()
+  , haswork()
+  , alldone()
+  , error()
+  {
+    const size_t helpers = numthreads > 1 ? (size_t)numthreads - 1 : 0;
+    threads.reserve(helpers);
+
+    for (size_t i = 0; i < helpers; ++i)
+    {
+      try
+      {
+        threads.emplace_back(&ParallelRunner::Serve, this);
+      }
+      catch (const std::system_error &)
+      {
+        // The loop runs on however many threads could be started
+        break;
+      }
+    }
+  }
+
+  ~ParallelRunner(void)
+  {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      stopping = true;
+      ++generation;
+    }
+    haswork.notify_all();
+
+    for (std::vector<std::thread>::iterator thread = threads.begin(); thread != threads.end(); ++thread)
+      thread->join();
+  }
+
+  ParallelRunner(const ParallelRunner &) = delete;
+  ParallelRunner& operator=(const ParallelRunner &) = delete;
+
+  // Calls fn for every value in [first, last), giving the next value to
+  // whichever thread is free, and returns once every value has been run.
+  // An exception thrown by fn abandons the rest of the loop and is rethrown
+  // here, whichever thread it came from.
+  template<typename Fn>
+  void Run(const size_t first, const size_t last, Fn &&fn)
+  {
+    if (threads.empty() || last <= first + 1)
+    {
+      for (size_t value = first; value < last; ++value)
+        fn(value);
+      return;
+    }
+
+    TypedJob<typename std::remove_reference<Fn>::type> typed(fn);
+
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      job = &typed;
+      next.store(first, std::memory_order_relaxed);
+      end = last;
+      outstanding = threads.size();
+      ++generation;
+    }
+    haswork.notify_all();
+
+    Claim(typed);
+    Wait();
+
+    if (error)
+    {
+      std::exception_ptr failure = error;
+      error = std::exception_ptr();
+      std::rethrow_exception(failure);
+    }
+  }
+
+private:
+  // The loop body for one Run, held without owning it
+  class Job
+  {
+  public:
+    virtual ~Job(void) {}
+    virtual void Call(size_t value) = 0;
+  };
+
+  template<typename Fn>
+  class TypedJob : public Job
+  {
+  public:
+    explicit TypedJob(Fn &fn) : fn(fn) {}
+    virtual void Call(const size_t value) { fn(value); }
+  private:
+    Fn &fn;
+  };
+
+  void Serve(void)
+  {
+    u64 seen = 0;
+
+    for (;;)
+    {
+      Job *running;
+
+      {
+        std::unique_lock<std::mutex> lock(mutex);
+        haswork.wait(lock, [&]{ return generation != seen; });
+        seen = generation;
+        if (stopping)
+          return;
+        running = job;
+      }
+
+      Claim(*running);
+
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        --outstanding;
+      }
+      alldone.notify_one();
+    }
+  }
+
+  void Wait(void)
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    alldone.wait(lock, [this]{ return outstanding == 0; });
+    job = 0;
+  }
+
+  void Claim(Job &running)
+  {
+    for (;;)
+    {
+      const size_t value = next.fetch_add(1, std::memory_order_relaxed);
+      if (value >= end)
+        return;
+
+      try
+      {
+        running.Call(value);
+      }
+      catch (...)
+      {
+        // The rest of the loop is abandoned, and the first failure is handed
+        // to the thread which called Run
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          if (!error)
+            error = std::current_exception();
+        }
+        next.store(end, std::memory_order_relaxed);
+        return;
+      }
+    }
+  }
+
+  std::vector<std::thread> threads;
+  Job                     *job;         // the body of the loop being run
+  std::atomic<size_t>      next;        // the next value a thread may claim
+  size_t                   end;         // one past the last value to run
+  u64                      generation;  // counts the loops handed to the threads
+  size_t                   outstanding; // threads still running the loop
+  bool                     stopping;
+  std::mutex               mutex;
+  std::condition_variable  haswork;     // a loop has been handed out
+  std::condition_variable  alldone;     // a thread has finished the loop
+  std::exception_ptr       error;       // the first failure of the loop body
+};
+
+// Calls fn for every value in [first, last), on numthreads threads, giving the
+// next value to whichever thread is free. One thread runs them in order.
+// A loop entered more than once should hold its own ParallelRunner instead.
+template<typename Fn>
+void foreach_parallel(const size_t first, const size_t last, const u32 numthreads, Fn &&fn)
+{
+  const size_t count = last > first ? last - first : 0;
+
+  ParallelRunner runner((u32)std::min<size_t>(numthreads, count));
+  runner.Run(first, last, std::forward<Fn>(fn));
+}
+
+template<typename T, typename Fn>
+void foreach_parallel(const std::vector<T> &collection, u32 numthreads, Fn &&fn)
+{
+  foreach_parallel(0, collection.size(), numthreads, [&](size_t index) { fn(collection[index]); });
+}
+
+#endif // __FOREACH_PARALLEL_H__

--- a/src/foreach_parallel_test.cpp
+++ b/src/foreach_parallel_test.cpp
@@ -1,0 +1,330 @@
+//  This file is part of par2cmdline (a PAR 2.0 compatible file verification and
+//  repair tool). See http://parchive.sourceforge.net for details of PAR 2.0.
+//
+//  par2cmdline is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  par2cmdline is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+#include <iostream>
+
+#include "libpar2internal.h"
+#include "foreach_parallel.h"
+
+
+// Counts how many times each value in [first, last) was run, and reports any
+// value which was not run exactly once
+static int check_counts(const char *what,
+                        const std::vector<std::atomic<int> > &counts,
+                        size_t first,
+                        size_t last)
+{
+  for (size_t i = 0; i < counts.size(); i++)
+  {
+    const int expected = (i >= first && i < last) ? 1 : 0;
+    if (counts[i].load() != expected)
+    {
+      std::cerr << what << ": value " << i << " ran " << counts[i].load()
+                << " times, expected " << expected << std::endl;
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+
+// Every value of a range runs exactly once, whatever the thread count
+int test1() {
+  const size_t size = 1000;
+
+  for (u32 numthreads = 1; numthreads <= 8; numthreads++)
+  {
+    std::vector<std::atomic<int> > counts(size);
+    for (size_t i = 0; i < size; i++)
+      counts[i].store(0);
+
+    foreach_parallel(0, size, numthreads, [&](size_t value) {
+      counts[value].fetch_add(1);
+    });
+
+    if (check_counts("test1", counts, 0, size))
+    {
+      std::cerr << "numthreads = " << numthreads << std::endl;
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+
+// A range which does not start at zero runs only its own values
+int test2() {
+  const size_t size = 64;
+
+  std::vector<std::atomic<int> > counts(size);
+  for (size_t i = 0; i < size; i++)
+    counts[i].store(0);
+
+  foreach_parallel(16, 48, 4, [&](size_t value) {
+    counts[value].fetch_add(1);
+  });
+
+  return check_counts("test2", counts, 16, 48);
+}
+
+
+// An empty range, a single value, and a backwards range
+int test3() {
+  const size_t size = 4;
+
+  for (u32 numthreads = 1; numthreads <= 4; numthreads++)
+  {
+    std::vector<std::atomic<int> > counts(size);
+    for (size_t i = 0; i < size; i++)
+      counts[i].store(0);
+
+    // Empty
+    foreach_parallel(2, 2, numthreads, [&](size_t value) {
+      counts[value].fetch_add(1);
+    });
+    if (check_counts("test3 empty", counts, 0, 0))
+      return 1;
+
+    // Backwards, which is also empty
+    foreach_parallel(3, 1, numthreads, [&](size_t value) {
+      counts[value].fetch_add(1);
+    });
+    if (check_counts("test3 backwards", counts, 0, 0))
+      return 1;
+
+    // A single value
+    foreach_parallel(1, 2, numthreads, [&](size_t value) {
+      counts[value].fetch_add(1);
+    });
+    if (check_counts("test3 single", counts, 1, 2))
+      return 1;
+  }
+
+  return 0;
+}
+
+
+// More threads than there are values to run
+int test4() {
+  const size_t size = 3;
+
+  std::vector<std::atomic<int> > counts(size);
+  for (size_t i = 0; i < size; i++)
+    counts[i].store(0);
+
+  foreach_parallel(0, size, 64, [&](size_t value) {
+    counts[value].fetch_add(1);
+  });
+
+  return check_counts("test4", counts, 0, size);
+}
+
+
+// The vector overload runs the loop over the elements of the collection
+int test5() {
+  std::vector<std::string> collection;
+  collection.push_back("one");
+  collection.push_back("two");
+  collection.push_back("three");
+
+  std::mutex mutex;
+  std::vector<std::string> seen;
+
+  foreach_parallel(collection, 4, [&](const std::string &value) {
+    std::lock_guard<std::mutex> lock(mutex);
+    seen.push_back(value);
+  });
+
+  std::sort(seen.begin(), seen.end());
+
+  if (seen.size() != collection.size())
+  {
+    std::cerr << "test5: saw " << seen.size() << " values, expected "
+              << collection.size() << std::endl;
+    return 1;
+  }
+  if (seen[0] != "one" || seen[1] != "three" || seen[2] != "two")
+  {
+    std::cerr << "test5: saw " << seen[0] << " " << seen[1] << " " << seen[2] << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
+
+
+// One runner runs many loops, each value of each of them exactly once
+int test6() {
+  const size_t size = 50;
+  const size_t loops = 100;
+
+  ParallelRunner runner(4);
+
+  for (size_t loop = 0; loop < loops; loop++)
+  {
+    std::vector<std::atomic<int> > counts(size);
+    for (size_t i = 0; i < size; i++)
+      counts[i].store(0);
+
+    runner.Run(0, size, [&](size_t value) {
+      counts[value].fetch_add(1);
+    });
+
+    if (check_counts("test6", counts, 0, size))
+    {
+      std::cerr << "loop = " << loop << std::endl;
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+
+// A runner with one thread, and with none, still runs every value
+int test7() {
+  const size_t size = 16;
+
+  for (u32 numthreads = 0; numthreads <= 1; numthreads++)
+  {
+    ParallelRunner runner(numthreads);
+
+    std::vector<std::atomic<int> > counts(size);
+    for (size_t i = 0; i < size; i++)
+      counts[i].store(0);
+
+    runner.Run(0, size, [&](size_t value) {
+      counts[value].fetch_add(1);
+    });
+
+    if (check_counts("test7", counts, 0, size))
+    {
+      std::cerr << "numthreads = " << numthreads << std::endl;
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+
+// An exception thrown by the loop body reaches the caller of Run
+int test8() {
+  ParallelRunner runner(4);
+
+  try
+  {
+    runner.Run(0, 64, [&](size_t value) {
+      if (value == 0)
+        throw std::runtime_error("from the loop body");
+    });
+  }
+  catch (const std::runtime_error &)
+  {
+    // The runner is still usable afterwards
+    std::atomic<int> ran(0);
+    runner.Run(0, 8, [&](size_t) { ran.fetch_add(1); });
+
+    if (ran.load() != 8)
+    {
+      std::cerr << "test8: ran " << ran.load() << " values after the throw, expected 8" << std::endl;
+      return 1;
+    }
+
+    return 0;
+  }
+
+  std::cerr << "test8: the exception did not reach the caller" << std::endl;
+  return 1;
+}
+
+
+// resolve_threads takes the default when nothing was asked for, and never
+// hands back more than MAX_THREAD_COUNT
+int test9() {
+  if (resolve_threads(0) != default_threads())
+  {
+    std::cerr << "test9: resolve_threads(0) = " << resolve_threads(0)
+              << ", expected " << default_threads() << std::endl;
+    return 1;
+  }
+  if (default_threads() < 1)
+  {
+    std::cerr << "test9: default_threads() = " << default_threads() << std::endl;
+    return 1;
+  }
+  if (resolve_threads(3) != 3)
+  {
+    std::cerr << "test9: resolve_threads(3) = " << resolve_threads(3) << std::endl;
+    return 1;
+  }
+  if (resolve_threads(1000000) != MAX_THREAD_COUNT)
+  {
+    std::cerr << "test9: resolve_threads(1000000) = " << resolve_threads(1000000)
+              << ", expected " << MAX_THREAD_COUNT << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
+
+
+int main() {
+  if (test1()) {
+    std::cerr << "FAILED: test1" << std::endl;
+    return 1;
+  }
+  if (test2()) {
+    std::cerr << "FAILED: test2" << std::endl;
+    return 1;
+  }
+  if (test3()) {
+    std::cerr << "FAILED: test3" << std::endl;
+    return 1;
+  }
+  if (test4()) {
+    std::cerr << "FAILED: test4" << std::endl;
+    return 1;
+  }
+  if (test5()) {
+    std::cerr << "FAILED: test5" << std::endl;
+    return 1;
+  }
+  if (test6()) {
+    std::cerr << "FAILED: test6" << std::endl;
+    return 1;
+  }
+  if (test7()) {
+    std::cerr << "FAILED: test7" << std::endl;
+    return 1;
+  }
+  if (test8()) {
+    std::cerr << "FAILED: test8" << std::endl;
+    return 1;
+  }
+  if (test9()) {
+    std::cerr << "FAILED: test9" << std::endl;
+    return 1;
+  }
+
+  std::cout << "SUCCESS: foreach_parallel_test complete." << std::endl;
+
+  return 0;
+}

--- a/src/libpar2.cpp
+++ b/src/libpar2.cpp
@@ -24,10 +24,8 @@ Result par2create(std::ostream &sout,
 		  const NoiseLevel noiselevel,
 		  const size_t memorylimit,
 		  const std::string &basepath,
-#ifdef _OPENMP
 		  const u32 nthreads,
 		  const u32 filethreads,
-#endif
 		  const std::string &parfilename,
 		  const std::vector<std::string> &extrafiles,
 		  const u64 blocksize,
@@ -41,10 +39,8 @@ Result par2create(std::ostream &sout,
   Result result = creator.Process(
 				  memorylimit,
 				  basepath,
-#ifdef _OPENMP
 				  nthreads,
 				  filethreads,
-#endif
 				  parfilename,
 				  extrafiles,
 				  blocksize,
@@ -62,10 +58,8 @@ Result par2repair(std::ostream &sout,
 		  const NoiseLevel noiselevel,
 		  const size_t memorylimit,
 		  const std::string &basepath,
-#ifdef _OPENMP
 		  const u32 nthreads,
 		  const u32 filethreads,
-#endif
 		  const std::string &parfilename,
 		  const std::vector<std::string> &extrafiles,
 		  const bool dorepair,   // derived from operation
@@ -80,10 +74,8 @@ Result par2repair(std::ostream &sout,
   Result result = repairer.Process(
 				   memorylimit,
 				   basepath,
-#ifdef _OPENMP
 				   nthreads,
 				   filethreads,
-#endif
 				   parfilename,
 				   extrafiles,
 				   dorepair,
@@ -102,10 +94,8 @@ Result par1repair(std::ostream &sout,
 		  const NoiseLevel noiselevel,
 		  const size_t memorylimit,
 		  // basepath is not used by Par1
-#ifdef _OPENMP
 		  const u32 nthreads,
 		  // filethreads is not used by Par1
-#endif
 		  const std::string &parfilename,
 		  const std::vector<std::string> &extrafiles,
 		  const bool dorepair,   // derived from operation
@@ -116,9 +106,7 @@ Result par1repair(std::ostream &sout,
 {
   Par1Repairer repairer(sout, serr, noiselevel);
   Result result = repairer.Process(memorylimit,
-#ifdef _OPENMP
 				   nthreads,
-#endif
 				   parfilename,
 				   extrafiles,
 				   dorepair,

--- a/src/libpar2.h
+++ b/src/libpar2.h
@@ -166,10 +166,8 @@ Result par2create(std::ostream &sout,
 			  const NoiseLevel noiselevel,
 			  const size_t memorylimit,
 			  const std::string &basepath,
-#ifdef _OPENMP
 			  const u32 nthreads,
 			  const u32 filethreads,
-#endif
 			  const std::string &parfilename,
 			  const std::vector<std::string> &extrafiles,
 			  const u64 blocksize,
@@ -185,10 +183,8 @@ Result par2repair(std::ostream &sout,
 		  const NoiseLevel noiselevel,
 		  const size_t memorylimit,
 		  const std::string &basepath,
-#ifdef _OPENMP
 		  const u32 nthreads,
 		  const u32 filethreads,
-#endif
 		  const std::string &parfilename,
 		  const std::vector<std::string> &extrafiles,
 		  const bool dorepair,   // derived from operation
@@ -205,10 +201,8 @@ Result par1repair(std::ostream &sout,
 		  const NoiseLevel noiselevel,
 		  const size_t memorylimit,
 		  // basepath is not used by Par1
-#ifdef _OPENMP
 		  const u32 nthreads,
 		  // filethreads is not used by Par1
-#endif
 		  const std::string &parfilename,
 		  const std::vector<std::string> &extrafiles,
 		  const bool dorepair,   // derived from operation

--- a/src/libpar2internal.h
+++ b/src/libpar2internal.h
@@ -244,6 +244,7 @@ private:
 #include "libpar2.h"
 
 #include "letype.h"
+#include "foreach_parallel.h"
 #include "progressmeter.h"
 
 #include "galois.h"
@@ -286,11 +287,5 @@ private:
 #include <crtdbg.h>
 #define DEBUG_NEW new(_NORMAL_BLOCK, THIS_FILE, __LINE__)
 #endif
-
-// OpenMP
-#ifdef _OPENMP
-# include <omp.h>
-#endif
-
 
 #endif // __PARCMDLINE_H__

--- a/src/par1repairer.cpp
+++ b/src/par1repairer.cpp
@@ -116,10 +116,8 @@ Par1Repairer::~Par1Repairer(void)
 
 Result Par1Repairer::Process(const size_t memorylimit,
 			     // basepath is not used by Par1
-#ifdef _OPENMP
 			     const u32 nthreads,
 			     // filethreads is not used by Par1
-#endif
 			     std::string parfilename,
 			     const std::vector<std::string> &extrafiles,
 			     const bool dorepair,   // derived from operation
@@ -128,12 +126,6 @@ Result Par1Repairer::Process(const size_t memorylimit,
 			     // skipleaway is not used by Par1
 			     )
 {
-#ifdef _OPENMP
-  // Set the number of threads
-  if (nthreads != 0)
-    omp_set_num_threads(nthreads);
-#endif
-
   // Determine the searchpath from the location of the main PAR file
   std::string name;
   DiskFile::SplitFilename(parfilename, searchpath, name);

--- a/src/par1repairer.h
+++ b/src/par1repairer.h
@@ -29,10 +29,8 @@ public:
 
   Result Process(const size_t memorylimit,
 		 // basepath is not used by Par1
-#ifdef _OPENMP
 		 const u32 nthreads,
 		 // filethreads is not used by Par1
-#endif
 		 std::string parfilename,
 		 const std::vector<std::string> &extrafiles,
 		 const bool dorepair,   // derived from operation

--- a/src/par2cmdline.cpp
+++ b/src/par2cmdline.cpp
@@ -84,10 +84,8 @@ int main(int argc, char* argv[])
 			    commandline->GetNoiseLevel(),
 			    commandline->GetMemoryLimit(),
 			    commandline->GetBasePath(),
-#ifdef _OPENMP
 			    commandline->GetNumThreads(),
 			    commandline->GetFileThreads(),
-#endif
 			    commandline->GetParFilename(),
 			    commandline->GetExtraFiles(),
 
@@ -111,9 +109,7 @@ int main(int argc, char* argv[])
 				  std::cerr,
 				  commandline->GetNoiseLevel(),
 				  commandline->GetMemoryLimit(),
-#ifdef _OPENMP
 				  commandline->GetNumThreads(),
-#endif
 				  commandline->GetParFilename(),
 				  commandline->GetExtraFiles(),
 				  commandline->GetOperation() == CommandLine::opRepair,
@@ -126,10 +122,8 @@ int main(int argc, char* argv[])
 				  commandline->GetNoiseLevel(),
 				  commandline->GetMemoryLimit(),
 				  commandline->GetBasePath(),
-#ifdef _OPENMP
 				  commandline->GetNumThreads(),
 				  commandline->GetFileThreads(),
-#endif
 				  commandline->GetParFilename(),
 				  commandline->GetExtraFiles(),
 				  commandline->GetOperation() == CommandLine::opRepair,

--- a/src/par2creator.cpp
+++ b/src/par2creator.cpp
@@ -29,16 +29,12 @@ static char THIS_FILE[]=__FILE__;
 #endif
 
 
-// static variable
-#ifdef _OPENMP
-u32 Par2Creator::filethreads = _FILE_THREADS;
-#endif
-
-
 Par2Creator::Par2Creator(std::ostream &sout, std::ostream &serr, const NoiseLevel noiselevel)
 : sout(sout)
 , serr(serr)
 , noiselevel(noiselevel)
+, totalthreads(default_threads())
+, filethreads(_FILE_THREADS)
 , blocksize(0)
 , chunksize(0)
 , inputbuffer(0)
@@ -87,10 +83,8 @@ Par2Creator::~Par2Creator(void)
 Result Par2Creator::Process(
 			    const size_t memorylimit,
 			    const std::string &basepath,
-#ifdef _OPENMP
 			    const u32 nthreads,
 			    const u32 _filethreads,
-#endif
 			    const std::string &parfilename,
 			    const std::vector<std::string> &_extrafiles,
 			    const u64 _blocksize,
@@ -99,9 +93,7 @@ Result Par2Creator::Process(
 			    const u32 _recoveryfilecount,
 			    const u32 _recoveryblockcount)
 {
-#ifdef _OPENMP
   filethreads = _filethreads;
-#endif
 
   if (!CheckBasepath(parfilename))
     return eFileIOError;
@@ -115,11 +107,8 @@ Result Par2Creator::Process(
   firstrecoveryblock = _firstblock;
   recoveryfilescheme = _recoveryfilescheme;
 
-#ifdef _OPENMP
   // Set the number of threads
-  if (nthreads != 0)
-    omp_set_num_threads(nthreads);
-#endif
+  totalthreads = resolve_threads(nthreads);
 
   // Compute block size from block count or vice versa depending on which was
   // specified on the command line
@@ -346,8 +335,7 @@ bool Par2Creator::CalculateProcessBlockSize(size_t memorylimit)
 // the results in the file verification and file description packets.
 bool Par2Creator::OpenSourceFiles(const std::vector<std::string> &extrafiles, std::string basepath)
 {
-#ifdef _OPENMP
-  bool openfailed = false;
+  std::atomic<bool> openfailed(false);
 
   //Total size of files for mt-progress line
   u64 mttotalsize = 0;
@@ -355,20 +343,16 @@ bool Par2Creator::OpenSourceFiles(const std::vector<std::string> &extrafiles, st
     mttotalsize += DiskFile::GetFileSize(extrafiles[i]);
 
   ProgressMeter<u64> progress(sout, "", mttotalsize);
-#endif
 
-  #pragma omp parallel for schedule(dynamic) num_threads(Par2Creator::GetFileThreads())
-  for (int i=0; i< static_cast<int>(extrafiles.size()); ++i)
+  foreach_parallel(extrafiles, GetFileThreads(), [&](const std::string &extrafile)
   {
-#ifdef _OPENMP
     if (openfailed)
-      continue;
-#endif
+      return;
 
     Par2CreatorSourceFile *sourcefile = new Par2CreatorSourceFile;
 
     std::string name;
-    DiskFile::SplitRelativeFilename(extrafiles[i], basepath, name);
+    DiskFile::SplitRelativeFilename(extrafile, basepath, name);
 
     if (noiselevel > nlSilent)
     {
@@ -376,19 +360,11 @@ bool Par2Creator::OpenSourceFiles(const std::vector<std::string> &extrafiles, st
     }
 
     // Open the source file and compute its Hashes and CRCs.
-#ifdef _OPENMP
-    if (!sourcefile->Open(noiselevel, sout, serr, extrafiles[i], blocksize, deferhashcomputation, basepath, progress))
-#else
-    if (!sourcefile->Open(noiselevel, sout, serr, extrafiles[i], blocksize, deferhashcomputation, basepath))
-#endif
+    if (!sourcefile->Open(noiselevel, sout, serr, extrafile, blocksize, deferhashcomputation, basepath, progress))
     {
       delete sourcefile;
-#ifdef _OPENMP
       openfailed = true;
-      continue;
-#else
-      return false;
-#endif
+      return;
     }
 
     // Record the file verification and file description packets
@@ -403,12 +379,10 @@ bool Par2Creator::OpenSourceFiles(const std::vector<std::string> &extrafiles, st
     // Close the source file until its needed
     sourcefile->Close();
 
-  }
+  });
 
-#ifdef _OPENMP
   if (openfailed)
     return false;
-#endif
 
   return true;
 }
@@ -791,6 +765,10 @@ bool Par2Creator::ProcessData(u64 blockoffset, size_t blocklength, ProgressMeter
 
   DiskFile *lastopenfile = NULL;
 
+  // The output blocks are divided between the same threads for every input
+  // block, so the threads are started once for the whole of the data
+  ParallelRunner runner(std::min<u32>(totalthreads, recoveryblockcount));
+
   // For each input block
   for ((sourceblock=sourceblocks.begin()),(inputblock=0);
        sourceblock != sourceblocks.end();
@@ -826,8 +804,7 @@ bool Par2Creator::ProcessData(u64 blockoffset, size_t blocklength, ProgressMeter
     }
 
     // For each output block
-    #pragma omp parallel for
-    for (i64 outputblock=0; outputblock<recoveryblockcount; outputblock++)
+    runner.Run(0, recoveryblockcount, [&](size_t outputblock)
     {
       u32 internalOutputblock = (u32)outputblock;
 
@@ -839,7 +816,7 @@ bool Par2Creator::ProcessData(u64 blockoffset, size_t blocklength, ProgressMeter
 
       if (noiselevel > nlQuiet)
         progress.Add(blocklength);
-    }
+    });
 
     // Work out which source file the next block belongs to
     if (++sourceindex >= (*sourcefile)->BlockCount())

--- a/src/par2creator.h
+++ b/src/par2creator.h
@@ -35,10 +35,8 @@ public:
   // Create recovery files from the source files specified on the command line
   Result Process(const size_t memorylimit,
 		 const std::string &basepath,
-#ifdef _OPENMP
 		 const u32 nthreads,
 		 const u32 filethreads,
-#endif
 		 const std::string &parfilename,
 		 const std::vector<std::string> &extrafiles,
 		 const u64 blocksize,
@@ -101,9 +99,7 @@ protected:
   // Close all files.
   bool CloseFiles(void);
 
-#ifdef _OPENMP
-  static u32                          GetFileThreads(void) {return filethreads;}
-#endif
+  u32                                 GetFileThreads(void) const {return filethreads;}
 
 protected:
   std::ostream &sout; // stream for output (for commandline, this is cout)
@@ -111,9 +107,8 @@ protected:
 
   const NoiseLevel noiselevel; // How noisy we should be
 
-#ifdef _OPENMP
-  static u32 filethreads;      // Number of threads for file processing
-#endif
+  u32 totalthreads;            // Number of threads the whole create may use
+  u32 filethreads;             // Number of threads for file processing
 
   u64 blocksize;      // The size of each block.
   size_t chunksize;   // How much of each block will be processed at a

--- a/src/par2creatorsourcefile.cpp
+++ b/src/par2creatorsourcefile.cpp
@@ -52,11 +52,7 @@ Par2CreatorSourceFile::~Par2CreatorSourceFile(void)
 // 16k of the file, and then compute the FileId and store the results
 // in a file description packet and a file verification packet.
 
-#ifdef _OPENMP
 bool Par2CreatorSourceFile::Open(NoiseLevel noiselevel, std::ostream &sout, std::ostream &serr, const std::string &extrafile, u64 blocksize, bool deferhashcomputation, std::string basepath, ProgressMeter<u64> &progress)
-#else
-bool Par2CreatorSourceFile::Open(NoiseLevel noiselevel, std::ostream &sout, std::ostream &serr, const std::string &extrafile, u64 blocksize, bool deferhashcomputation, std::string basepath)
-#endif
 {
   // Get the filename and filesize
   diskfilename = extrafile;
@@ -138,9 +134,6 @@ bool Par2CreatorSourceFile::Open(NoiseLevel noiselevel, std::ostream &sout, std:
     MD5Context filecontext;
     MD5Context blockcontext;
     u32        blockcrc = 0;
-#ifndef _OPENMP
-    ProgressMeter<u64> progress(sout, "", filesize);
-#endif
 
     // Whilst we have not reached the end of the file
     while (offset < filesize)

--- a/src/par2creatorsourcefile.h
+++ b/src/par2creatorsourcefile.h
@@ -40,11 +40,7 @@ public:
   ~Par2CreatorSourceFile(void);
 
   // Open the source file and compute the Hashes and CRCs.
-#ifdef _OPENMP
   bool Open(NoiseLevel noiselevel, std::ostream &sout, std::ostream &serr, const std::string &extrafile, u64 blocksize, bool deferhashcomputation, std::string basepath, ProgressMeter<u64> &progress);
-#else
-  bool Open(NoiseLevel noiselevel, std::ostream &sout, std::ostream &serr, const std::string &extrafile, u64 blocksize, bool deferhashcomputation, std::string basepath);
-#endif
   void Close(void);
 
   // Recover the file description and file verification packets

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -28,18 +28,6 @@ static char THIS_FILE[]=__FILE__;
 #endif
 #endif
 
-#ifdef _OPENMP
-#define MT_PROGRESS , progress
-#else
-#define MT_PROGRESS
-#endif
-
-
-#ifdef _OPENMP
-u32 Par2Repairer::filethreads = _FILE_THREADS;
-#endif
-
-
 // Test whether filename has a .par2 / .PAR2 / .Par2 extension.
 bool Par2Repairer::IsPar2Filename(const std::string &filename)
 {
@@ -63,6 +51,9 @@ Par2Repairer::Par2Repairer(std::ostream &sout, std::ostream &serr, const NoiseLe
 , noiselevel(noiselevel)
 , searchpath()
 , basepath()
+, totalthreads(default_threads())
+, filethreads(_FILE_THREADS)
+, blockthreads(1)
 , setid()
 , recoverypacketmap()
 , diskFileMap()
@@ -137,10 +128,8 @@ Par2Repairer::~Par2Repairer(void)
 Result Par2Repairer::Process(
 			     const size_t memorylimit,
 			     const std::string &_basepath,
-#ifdef _OPENMP
 			     const u32 nthreads,
 			     const u32 _filethreads,
-#endif
 			     std::string parfilename,
 			     const std::vector<std::string> &_extrafiles,
 			     const bool dorepair,   // derived from operation
@@ -164,22 +153,11 @@ Result Par2Repairer::Process(
   basepath = _basepath;
   std::vector<std::string> extrafiles = _extrafiles;
 
-#ifdef _OPENMP
   // Set the number of threads
-  if (nthreads != 0)
-    omp_set_num_threads(nthreads);
+  totalthreads = resolve_threads(nthreads);
 
   // No more files are read at once than there are threads to hash them with
-  filethreads = std::min(_filethreads, (u32)omp_get_max_threads());
-
-  // Files are scanned in parallel, and so are the blocks within one file,
-  // so both levels need to be able to run threads.
-#if _OPENMP >= 200805
-  omp_set_max_active_levels(2);
-#else
-  omp_set_nested(1);
-#endif
-#endif
+  filethreads = std::min(_filethreads, totalthreads);
 
   // Determine the searchpath from the location of the main PAR2 file
   std::string name;
@@ -1007,10 +985,8 @@ bool Par2Repairer::CreateSourceFileList(void)
     {
       sourcefile->ComputeTargetFileName(sout, serr, noiselevel, basepath);
 
-#ifdef _OPENMP
       // Need actual filesize on disk for mt-progress line
       sourcefile->SetDiskFileSize();
-#endif
     }
 
     sourcefiles.push_back(sourcefile);
@@ -1186,7 +1162,7 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
   if (noiselevel > nlQuiet)
     sout << "\nVerifying source files:\n" << std::endl;
 
-  bool finalresult = true;
+  std::atomic<bool> finalresult(true);
 
   // Created a sorted list of the source files and verify them in that
   // order rather than the order they are in the main packet.
@@ -1195,9 +1171,7 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
   u32 filenumber = 0;
   std::vector<Par2RepairerSourceFile*>::iterator sf = sourcefiles.begin();
 
-#ifdef _OPENMP
   u64 mttotalsize = 0;
-#endif
 
   while (sf != sourcefiles.end())
   {
@@ -1206,10 +1180,8 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
     if (sourcefile)
     {
       sortedfiles.push_back(sourcefile);
-#ifdef _OPENMP
       // Total filesizes for mt-progress line
       mttotalsize += sourcefile->DiskFileSize();
-#endif
      }
     else
     {
@@ -1232,17 +1204,11 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
   }
 
   std::sort(sortedfiles.begin(), sortedfiles.end(), SortSourceFilesByFileName);
-#ifdef _OPENMP
   ProgressMeter<u64> progress(sout, "Scanning: ", mttotalsize);
-#endif
 
   // Start verifying the files
-  #pragma omp parallel for schedule(dynamic) num_threads(Par2Repairer::FileThreads(sortedfiles.size()))
-  for (int i=0; i< static_cast<int>(sortedfiles.size()); ++i)
+  foreach_parallel(sortedfiles, SetBlockThreads(sortedfiles.size()), [&](Par2RepairerSourceFile *sourcefile)
   {
-    // Do we have a source file
-    Par2RepairerSourceFile *sourcefile = sortedfiles[i];
-
     // What filename does the file use
     const std::string& file = sourcefile->TargetFileName();
     const std::string& name = DiskFile::SplitRelativeFilename(file, basepath);
@@ -1307,7 +1273,7 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
         }
         assert(success);
         // Do the actual verification
-        if (!VerifyDataFile(diskfile, sourcefile, basepath MT_PROGRESS))
+        if (!VerifyDataFile(diskfile, sourcefile, basepath, progress))
           finalresult = false;
 
         // We have finished with the file for now
@@ -1324,7 +1290,7 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
         }
       }
     }
-  }
+  });
 
   // Find out how much data we have found
   UpdateVerificationResults();
@@ -1340,19 +1306,16 @@ bool Par2Repairer::VerifyExtraFiles(const std::vector<std::string> &extrafiles, 
 
   if (completefilecount < mainpacket->RecoverableFileCount())
   {
-#ifdef _OPENMP
     // Total size of extra files for mt-progress line
     u64 mttotalextrasize = 0;
     for (size_t i=0; i<extrafiles.size(); ++i)
       mttotalextrasize += DiskFile::GetFileSize(extrafiles[i]);
 
     ProgressMeter<u64> progress(sout, "Scanning: ", mttotalextrasize);
-#endif
 
-    #pragma omp parallel for schedule(dynamic) num_threads(Par2Repairer::FileThreads(extrafiles.size()))
-    for (int i=0; i< static_cast<int>(extrafiles.size()); ++i)
+    foreach_parallel(extrafiles, SetBlockThreads(extrafiles.size()), [&](const std::string &extrafile)
     {
-      std::string filename = extrafiles[i];
+      std::string filename = extrafile;
 
       // If the filename does not have a .par2 / .PAR2 / .Par2 extension we are interested in it.
       if (!IsPar2Filename(filename))
@@ -1373,7 +1336,7 @@ bool Par2Repairer::VerifyExtraFiles(const std::vector<std::string> &extrafiles, 
           if (!diskfile->Open(filename))
           {
             delete diskfile;
-            continue;
+            return;
           }
 
           // Remember that we have processed this file
@@ -1385,14 +1348,14 @@ bool Par2Repairer::VerifyExtraFiles(const std::vector<std::string> &extrafiles, 
           assert(success);
 
           // Do the actual verification
-          VerifyDataFile(diskfile, 0, basepath MT_PROGRESS, renameonly);
+          VerifyDataFile(diskfile, 0, basepath, progress, renameonly);
           // Ignore errors
 
           // We have finished with the file for now
           diskfile->Close();
         }
       }
-    }
+    });
   }
   // Find out how much data we have found
   UpdateVerificationResults();
@@ -1401,11 +1364,7 @@ bool Par2Repairer::VerifyExtraFiles(const std::vector<std::string> &extrafiles, 
 }
 
 // Attempt to match the data in the DiskFile with the source file
-#ifdef _OPENMP
 bool Par2Repairer::VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const std::string &basepath, ProgressMeter<u64> &progress, const bool renameonly)
-#else
-bool Par2Repairer::VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const std::string &basepath, const bool renameonly)
-#endif
 {
   MatchType matchtype; // What type of match was made
   MD5Hash hashfull;    // The MD5 Hash of the whole file
@@ -1419,8 +1378,8 @@ bool Par2Repairer::VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *so
     // Scan the file at the block level.
 
     if (!ScanDataFile(diskfile,   // [in]      The file to scan
-                      basepath
-                      MT_PROGRESS,
+                      basepath,
+                      progress,
                       renameonly, // [in]      Only look for perfect matches
                       sourcefile, // [in/out]  Modified in the match is for another source file
                       matchtype,  // [out]
@@ -1607,11 +1566,7 @@ bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [i
   if (0 == blockcount)
     return false;
 
-#ifdef _OPENMP
-  const u32 workers = std::max(1u, (u32)omp_get_max_threads() / (u32)std::max(1, omp_get_num_threads()));
-#else
-  const u32 workers = 1;
-#endif
+  const u32 workers = blockthreads;
 
   // A single thread gains nothing from checking the blocks up front, and a
   // damaged file would then be read a second time by the scan below
@@ -1780,9 +1735,7 @@ bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [i
 // found is for a different source file then "sourcefile" is changed accordingly.
 bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
                                 std::string             basepath,     // [in]
-#ifdef _OPENMP
                                 ProgressMeter<u64>      &progress,    // [in]
-#endif
                                 const bool              renameonly,   // [in]
                                 Par2RepairerSourceFile* &sourcefile,  // [in/out]
                                 MatchType               &matchtype,   // [out]
@@ -1836,16 +1789,10 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
     shortname = name;
   }
 
-#ifdef _OPENMP
   if (noiselevel > nlQuiet)
   {
     LockedStream(sout) << "Opening: \"" << shortname << "\"" << std::endl;
   }
-#else
-  std::string message = "Scanning: \"";
-  message.append(shortname).append("\": ");
-  ProgressMeter<u64> progress(sout, message, diskfile->FileSize());
-#endif
 
   // Assume we will make a perfect match for the file
   matchtype = eFullMatch;
@@ -2764,6 +2711,10 @@ bool Par2Repairer::ProcessData(u64 blockoffset, size_t blocklength, ProgressMete
   // Are there any blocks which need to be reconstructed
   if (missingblockcount > 0)
   {
+    // The output blocks are divided between the same threads for every input
+    // block, so the threads are started once for the whole of the data
+    ParallelRunner runner(std::min<u32>(totalthreads, missingblockcount));
+
     // For each input block
     while (inputblock != inputblocks.end())
     {
@@ -2806,8 +2757,7 @@ bool Par2Repairer::ProcessData(u64 blockoffset, size_t blocklength, ProgressMete
       }
 
       // For each output block
-      #pragma omp parallel for
-      for (i64 outputindex=0; outputindex<missingblockcount; outputindex++)
+      runner.Run(0, missingblockcount, [&](size_t outputindex)
       {
         u32 internalOutputindex = (u32) outputindex;
         // Select the appropriate part of the output buffer
@@ -2818,7 +2768,7 @@ bool Par2Repairer::ProcessData(u64 blockoffset, size_t blocklength, ProgressMete
 
         if (noiselevel > nlQuiet)
           progress.Add(blocklength);
-      }
+      });
 
       ++inputblock;
       ++inputindex;
@@ -2903,12 +2853,11 @@ bool Par2Repairer::ProcessData(u64 blockoffset, size_t blocklength, ProgressMete
 // Verify that all of the reconstructed target files are now correct
 bool Par2Repairer::VerifyTargetFiles(const std::string &basepath)
 {
-  bool finalresult = true;
+  std::atomic<bool> finalresult(true);
 
   // Verify the target files in alphabetical order
   std::sort(verifylist.begin(), verifylist.end(), SortSourceFilesByFileName);
 
-#ifdef _OPENMP
   u64 mttotalsize = 0;
 
   for (size_t i=0; i<verifylist.size(); ++i)
@@ -2917,13 +2866,10 @@ bool Par2Repairer::VerifyTargetFiles(const std::string &basepath)
       mttotalsize += verifylist[i]->GetDescriptionPacket()->FileSize();
   }
   ProgressMeter<u64> progress(sout, "Scanning: ", mttotalsize);
-#endif
 
   // Iterate through each file in the verification list
-  #pragma omp parallel for schedule(dynamic) num_threads(Par2Repairer::FileThreads(verifylist.size()))
-  for (int i=0; i< static_cast<int>(verifylist.size()); ++i)
+  foreach_parallel(verifylist, SetBlockThreads(verifylist.size()), [&](Par2RepairerSourceFile *sourcefile)
   {
-    Par2RepairerSourceFile *sourcefile = verifylist[i];
     DiskFile *targetfile = sourcefile->GetTargetFile();
 
     // Close the file
@@ -2945,16 +2891,16 @@ bool Par2Repairer::VerifyTargetFiles(const std::string &basepath)
     if (!targetfile->Open())
     {
       finalresult = false;
-      continue;
+      return;
     }
 
     // Verify the file again
-    if (!VerifyDataFile(targetfile, sourcefile, basepath MT_PROGRESS))
+    if (!VerifyDataFile(targetfile, sourcefile, basepath, progress))
       finalresult = false;
 
     // Close the file again
     targetfile->Close();
-  }
+  });
 
   // Find out how much data we have found
   UpdateVerificationResults();

--- a/src/par2repairer.h
+++ b/src/par2repairer.h
@@ -29,10 +29,8 @@ public:
 
   Result Process(const size_t memorylimit,
 		 const std::string &basepath,
-#ifdef _OPENMP
 		 const u32 nthreads,
 		 const u32 filethreads,
-#endif
 		 std::string parfilename,
 		 const std::vector<std::string> &extrafiles,
 		 const bool dorepair,   // derived from operation
@@ -94,11 +92,7 @@ protected:
   bool VerifyExtraFiles(const std::vector<std::string> &extrafiles, const std::string &basepath, const bool renameonly);
 
   // Attempt to match the data in the DiskFile with the source file
-#ifdef _OPENMP
   bool VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const std::string &basepath, ProgressMeter<u64> &progress, const bool renameonly = false);
-#else
-  bool VerifyDataFile(DiskFile *diskfile, Par2RepairerSourceFile *sourcefile, const std::string &basepath, const bool renameonly = false);
-#endif
 
   // Check the blocks of a source file at the offsets where they are expected
   // to be found. One thread reads the file in order while the others check the
@@ -120,9 +114,7 @@ protected:
   // found is for a different source file then "sourcefile" is changed accordingly.
   bool ScanDataFile(DiskFile                *diskfile,   // [in]     The file being scanned
                     std::string             basepath,    // [in]
-#ifdef _OPENMP
                     ProgressMeter<u64>      &progress,   // [in]
-#endif
                     const bool              renameonly,  // [in]     Only look for perfect matches
                     Par2RepairerSourceFile* &sourcefile, // [in/out] The source file matched
                     MatchType               &matchtype,  // [out]    The type of match
@@ -164,10 +156,17 @@ protected:
   bool RemoveBackupFiles(void);
   bool RemoveParFiles(void);
 
-#ifdef _OPENMP
-  static u32                          FileThreads(size_t filecount)
+  u32                                 FileThreads(size_t filecount) const
     {return (u32)std::max<size_t>(1, std::min<size_t>(filethreads, filecount));}
-#endif
+
+  // Divides the threads between the files scanned at once and the blocks
+  // checked within one file. Returns the number of files to scan at once.
+  u32                                 SetBlockThreads(size_t filecount)
+    {
+      const u32 files = FileThreads(filecount);
+      blockthreads = std::max(1u, totalthreads / files);
+      return files;
+    }
 
 protected:
   std::ostream &sout; // stream for output (for commandline, this is cout)
@@ -179,9 +178,9 @@ protected:
 
   std::string               basepath;
 
-#ifdef _OPENMP
-  static u32 filethreads;      // Number of threads for file processing
-#endif
+  u32 totalthreads;            // Number of threads the whole repair may use
+  u32 filethreads;             // Number of threads for file processing
+  u32 blockthreads;            // Number of threads left to check one file's blocks
 
   bool                      skipdata;                // Should we skip data whilst scanning
   u64                       skipleaway;              // The leaway +/- we should allow whilst scanning

--- a/src/par2repairersourcefile.cpp
+++ b/src/par2repairersourcefile.cpp
@@ -46,9 +46,7 @@ Par2RepairerSourceFile::Par2RepairerSourceFile(DescriptionPacket *_descriptionpa
   targetfile = 0;
   completefile = 0;
 
-#ifdef _OPENMP
   diskfilesize = 0;
-#endif
 }
 
 Par2RepairerSourceFile::~Par2RepairerSourceFile(void)
@@ -167,9 +165,7 @@ bool Par2RepairerSourceFile::SetBlockCount(u64 blocksize)
   return true;
 }
 
-#ifdef _OPENMP
 void Par2RepairerSourceFile::SetDiskFileSize()
 {
   diskfilesize = DiskFile::GetFileSize(targetfilename);
 }
-#endif

--- a/src/par2repairersourcefile.h
+++ b/src/par2repairersourcefile.h
@@ -87,11 +87,9 @@ public:
   // Get the first target DataBlock for the file
   std::vector<DataBlock>::iterator TargetBlocks(void) const {return targetblocks;}
 
-#if _OPENMP
   // Set/Get "filesize on disk" needed for mt progress line
   void SetDiskFileSize();
   u64 DiskFileSize(void) const {return diskfilesize;}
-#endif
 
 protected:
   DescriptionPacket           *descriptionpacket;   // The file description packet
@@ -108,9 +106,7 @@ protected:
   DiskFile                    *completefile;        // A complete version of the file
 
   std::string                  targetfilename;      // The filename of the target file
-#if _OPENMP
   u64                          diskfilesize;        // The filesize of sourcefile on disk
-#endif
 };
 
 #endif // __PAR2REPAIRERSOURCEFILE_H__

--- a/tests/foreach_parallel_test.vcxproj
+++ b/tests/foreach_parallel_test.vcxproj
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{9a1d7f6c-2b48-4d5e-8c31-5f0b7e4a2d19}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="..\par2cmdline.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\foreach_parallel_test.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\libpar2.vcxproj">
+      <Project>{d0a94f83-495e-4fb2-ac33-9a3ec2cc263b}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\src\foreach_parallel.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/tests/test45
+++ b/tests/test45
@@ -35,14 +35,6 @@ echo $dashes
 echo $banner
 echo $dashes
 
-# The -t option only exists when built with thread support
-if ! $PARBINARY -h 2>&1 | grep -q '^  -t<n>'; then
-    echo "Skipping: par2 was built without thread support."
-    cd "$TESTROOT"
-    rm -rf "run$testname"
-    exit 77
-fi
-
 # Build a data file of 64 blocks of 1024 bytes
 i=0
 while [ $i -lt 1024 ]; do

--- a/tests/test45.ps1
+++ b/tests/test45.ps1
@@ -13,14 +13,6 @@ try {
 
     Write-Banner "Scanning the blocks of a file in parallel finds the same data"
 
-    # The -t option only exists when built with thread support
-    $help = Invoke-Par2 -Arguments @("-h") -ReturnObject
-    if ($help.StdOut -notmatch "(?m)^  -t<n>") {
-        Write-Host "Skipping: par2 was built without thread support."
-        Complete-Test
-        exit 77
-    }
-
     # Build a data file of 64 blocks of 1024 bytes
     $builder = New-Object System.Text.StringBuilder
     for ($i = 0; $i -lt 1024; $i++) {

--- a/tests/test47
+++ b/tests/test47
@@ -35,14 +35,6 @@ echo $dashes
 echo $banner
 echo $dashes
 
-# The -T option only exists when built with thread support
-if ! $PARBINARY -h 2>&1 | grep -q '^  -T<n>'; then
-    echo "Skipping: par2 was built without thread support."
-    cd "$TESTROOT"
-    rm -rf "run$testname"
-    exit 77
-fi
-
 # Build four data files of 16 blocks of 1024 bytes. Each file holds different
 # data so that a block cannot be matched against the wrong file.
 for n in 1 2 3 4

--- a/tests/test47.ps1
+++ b/tests/test47.ps1
@@ -13,14 +13,6 @@ try {
 
     Write-Banner "Reading several files at once finds the same data"
 
-    # The -T option only exists when built with thread support
-    $help = Invoke-Par2 -Arguments @("-h") -ReturnObject
-    if ($help.StdOut -notmatch "(?m)^  -T<n>") {
-        Write-Host "Skipping: par2 was built without thread support."
-        Complete-Test
-        exit 77
-    }
-
     # Build four data files of 16 blocks of 1024 bytes. Each file holds
     # different data so that a block cannot be matched against the wrong file.
     foreach ($n in 1..4) {

--- a/tests/test48
+++ b/tests/test48
@@ -49,21 +49,13 @@ then
     exit 1
 fi
 
-# The -t option only exists when built with thread support
-if $PARBINARY -h 2>&1 | grep -q '^  -t<n>'
-then
-    threadopts="-t1 -t4"
-else
-    threadopts=""
-fi
-
 # The whole file hash recorded for it does not match, which only shows up when
 # the whole of the file is hashed as well. A single thread leaves the whole
 # file to the byte at a time search, and several threads have the thread which
 # reads the file hash it, so both have to notice. The file is damaged rather
 # than unreadable, so the exit code is checked rather than just being non-zero,
 # which an unrecognised option would also give.
-for opt in "" $threadopts
+for opt in "" -t1 -t4
 do
     $PARBINARY v -q $opt --full-hash recovery.par2 > whole.out 2>&1
     whole=$?

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -1,30 +1,3 @@
-# libgomp (the OpenMP runtime) keeps its worker thread pool alive for the
-# lifetime of the process. The TLS/DTV blocks that glibc allocates for the
-# pooled threads (via pthread_create -> _dl_allocate_tls) are only released
-# when the pool is torn down at exit, which valgrind cannot track reliably.
-# These "possibly lost" reports are false positives
-{
-   libgomp_thread_pool_tls
-   Memcheck:Leak
-   match-leak-kinds: possible,reachable
-   fun:calloc
-   ...
-   fun:pthread_create*
-   obj:*/libgomp.so*
-}
-
-# libgomp allocates its global state from an ELF constructor when the library
-# is loaded, and its per-team state on entry to a parallel region. Both are
-# held inside the runtime until the process exits
-{
-   libgomp_internal_state
-   Memcheck:Leak
-   match-leak-kinds: possible,reachable
-   fun:*
-   obj:*/libgomp.so*
-   obj:*/libgomp.so*
-}
-
 # Unsynchronising the C++ streams from C stdio gives cin/cout/cerr and their
 # wide counterparts their own filebufs, whose buffers belong to static objects
 # and are never freed


### PR DESCRIPTION
Fixes #309

foreach_parallel is adapted from par2cmdline-turbo, where it has stood in for `schedule(dynamic)` since their remove_openmp work. Two differences: turbo's third branch, which spawns one std::async per item when threads outnumber items, is dropped in favour of capping the pool at the item count; and an index-range overload is added for the two Reed-Solomon loops, which walk output blocks rather than a container.

That covers the four file-level loops and the two compute loops. OPENMP_CXXFLAGS, AC_OPENMP and the .vcxproj settings then go with them.

Dropping the `#ifdef _OPENMP` guards makes -t and -T always available, where before they existed only in an OpenMP build, and -t reports std::thread::hardware_concurrency().