### PR TITLE
Check the blocks of every file on one shared pool of threads

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,7 @@ libpar2_a_SOURCES = src/crc.cpp src/crc.h \
 	src/par2repairer.cpp src/par2repairer.h \
 	src/par2repairersourcefile.cpp src/par2repairersourcefile.h \
 	src/foreach_parallel.h \
+	src/bufferpool.h \
 	src/taskpool.h \
 	src/progressmeter.h \
 	src/recoverypacket.cpp src/recoverypacket.h \
@@ -200,7 +201,7 @@ EXTRA_DIST = \
 
 # Programs that need to be compiled for the test suite.
 # These are the unit tests.
-check_PROGRAMS = tests/letype_test tests/crc_test tests/md5_test tests/diskfile_test tests/filechecksummer_test tests/libpar2_test tests/commandline_test tests/descriptionpacket_test tests/criticalpacket_test tests/reedsolomon_test tests/galois_test tests/foreach_parallel_test tests/taskpool_test tests/utf8_test
+check_PROGRAMS = tests/letype_test tests/crc_test tests/md5_test tests/diskfile_test tests/filechecksummer_test tests/libpar2_test tests/commandline_test tests/descriptionpacket_test tests/criticalpacket_test tests/reedsolomon_test tests/galois_test tests/foreach_parallel_test tests/taskpool_test tests/bufferpool_test tests/utf8_test
 
 tests_letype_test_SOURCES = src/letype_test.cpp src/letype.h
 
@@ -235,6 +236,9 @@ tests_foreach_parallel_test_LDADD = libpar2.a
 
 tests_taskpool_test_SOURCES = src/taskpool_test.cpp src/taskpool.h
 tests_taskpool_test_LDADD = libpar2.a
+
+tests_bufferpool_test_SOURCES = src/bufferpool_test.cpp src/bufferpool.h
+tests_bufferpool_test_LDADD = libpar2.a
 
 tests_utf8_test_SOURCES = src/utf8_test.cpp src/utf8.cpp src/utf8.h
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,7 @@ libpar2_a_SOURCES = src/crc.cpp src/crc.h \
 	src/par2repairer.cpp src/par2repairer.h \
 	src/par2repairersourcefile.cpp src/par2repairersourcefile.h \
 	src/foreach_parallel.h \
+	src/taskpool.h \
 	src/progressmeter.h \
 	src/recoverypacket.cpp src/recoverypacket.h \
 	src/reedsolomon.cpp src/reedsolomon.h \
@@ -199,7 +200,7 @@ EXTRA_DIST = \
 
 # Programs that need to be compiled for the test suite.
 # These are the unit tests.
-check_PROGRAMS = tests/letype_test tests/crc_test tests/md5_test tests/diskfile_test tests/filechecksummer_test tests/libpar2_test tests/commandline_test tests/descriptionpacket_test tests/criticalpacket_test tests/reedsolomon_test tests/galois_test tests/foreach_parallel_test tests/utf8_test
+check_PROGRAMS = tests/letype_test tests/crc_test tests/md5_test tests/diskfile_test tests/filechecksummer_test tests/libpar2_test tests/commandline_test tests/descriptionpacket_test tests/criticalpacket_test tests/reedsolomon_test tests/galois_test tests/foreach_parallel_test tests/taskpool_test tests/utf8_test
 
 tests_letype_test_SOURCES = src/letype_test.cpp src/letype.h
 
@@ -231,6 +232,9 @@ tests_galois_test_SOURCES = src/galois_test.cpp src/galois.cpp src/galois.h
 
 tests_foreach_parallel_test_SOURCES = src/foreach_parallel_test.cpp src/foreach_parallel.h
 tests_foreach_parallel_test_LDADD = libpar2.a
+
+tests_taskpool_test_SOURCES = src/taskpool_test.cpp src/taskpool.h
+tests_taskpool_test_LDADD = libpar2.a
 
 tests_utf8_test_SOURCES = src/utf8_test.cpp src/utf8.cpp src/utf8.h
 

--- a/libpar2.vcxproj
+++ b/libpar2.vcxproj
@@ -104,6 +104,7 @@
     <ClInclude Include="src\par2repairer.h" />
     <ClInclude Include="src\par2repairersourcefile.h" />
     <ClInclude Include="src\foreach_parallel.h" />
+    <ClInclude Include="src\bufferpool.h" />
     <ClInclude Include="src\taskpool.h" />
     <ClInclude Include="src\progressmeter.h" />
     <ClInclude Include="src\recoverypacket.h" />

--- a/libpar2.vcxproj
+++ b/libpar2.vcxproj
@@ -104,6 +104,7 @@
     <ClInclude Include="src\par2repairer.h" />
     <ClInclude Include="src\par2repairersourcefile.h" />
     <ClInclude Include="src\foreach_parallel.h" />
+    <ClInclude Include="src\taskpool.h" />
     <ClInclude Include="src\progressmeter.h" />
     <ClInclude Include="src\recoverypacket.h" />
     <ClInclude Include="src\reedsolomon.h" />

--- a/libpar2.vcxproj.filters
+++ b/libpar2.vcxproj.filters
@@ -149,6 +149,9 @@
     <ClInclude Include="src\foreach_parallel.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\bufferpool.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="src\taskpool.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/libpar2.vcxproj.filters
+++ b/libpar2.vcxproj.filters
@@ -149,6 +149,9 @@
     <ClInclude Include="src\foreach_parallel.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\taskpool.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="src\progressmeter.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/par2cmdline.sln
+++ b/par2cmdline.sln
@@ -34,6 +34,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "criticalpacket_test", "test
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "foreach_parallel_test", "tests\foreach_parallel_test.vcxproj", "{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "taskpool_test", "tests\taskpool_test.vcxproj", "{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -326,6 +328,24 @@ Global
 		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.UnitTests-Release|Win32.Build.0 = Release|Win32
 		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.UnitTests-Release|x64.ActiveCfg = Release|x64
 		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19}.UnitTests-Release|x64.Build.0 = Release|x64
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.Debug|Win32.ActiveCfg = Debug|Win32
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.Debug|x64.ActiveCfg = Debug|x64
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.Release|ARM64.ActiveCfg = Release|ARM64
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.Release|Win32.ActiveCfg = Release|Win32
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.Release|x64.ActiveCfg = Release|x64
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.UnitTests-Debug|ARM64.ActiveCfg = Debug|ARM64
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.UnitTests-Debug|ARM64.Build.0 = Debug|ARM64
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.UnitTests-Debug|Win32.ActiveCfg = Debug|Win32
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.UnitTests-Debug|Win32.Build.0 = Debug|Win32
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.UnitTests-Debug|x64.ActiveCfg = Debug|x64
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.UnitTests-Debug|x64.Build.0 = Debug|x64
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.UnitTests-Release|ARM64.ActiveCfg = Release|ARM64
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.UnitTests-Release|ARM64.Build.0 = Release|ARM64
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.UnitTests-Release|Win32.ActiveCfg = Release|Win32
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.UnitTests-Release|Win32.Build.0 = Release|Win32
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.UnitTests-Release|x64.ActiveCfg = Release|x64
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.UnitTests-Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -344,6 +364,7 @@ Global
 		{4E77EA22-B1FA-4FC0-8E13-74953DE245D7} = {09795456-9DA5-4253-AE04-DD2AB464238A}
 		{862B6ABA-D1C6-4DB8-A893-747CC8B5D0F2} = {09795456-9DA5-4253-AE04-DD2AB464238A}
 		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19} = {09795456-9DA5-4253-AE04-DD2AB464238A}
+		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF} = {09795456-9DA5-4253-AE04-DD2AB464238A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {06E89BF8-F199-48B1-94CB-D7BB1B23DDD9}

--- a/par2cmdline.sln
+++ b/par2cmdline.sln
@@ -36,6 +36,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "foreach_parallel_test", "te
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "taskpool_test", "tests\taskpool_test.vcxproj", "{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bufferpool_test", "tests\bufferpool_test.vcxproj", "{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -346,6 +348,24 @@ Global
 		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.UnitTests-Release|Win32.Build.0 = Release|Win32
 		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.UnitTests-Release|x64.ActiveCfg = Release|x64
 		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF}.UnitTests-Release|x64.Build.0 = Release|x64
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.Debug|Win32.ActiveCfg = Debug|Win32
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.Debug|x64.ActiveCfg = Debug|x64
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.Release|ARM64.ActiveCfg = Release|ARM64
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.Release|Win32.ActiveCfg = Release|Win32
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.Release|x64.ActiveCfg = Release|x64
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.UnitTests-Debug|ARM64.ActiveCfg = Debug|ARM64
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.UnitTests-Debug|ARM64.Build.0 = Debug|ARM64
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.UnitTests-Debug|Win32.ActiveCfg = Debug|Win32
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.UnitTests-Debug|Win32.Build.0 = Debug|Win32
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.UnitTests-Debug|x64.ActiveCfg = Debug|x64
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.UnitTests-Debug|x64.Build.0 = Debug|x64
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.UnitTests-Release|ARM64.ActiveCfg = Release|ARM64
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.UnitTests-Release|ARM64.Build.0 = Release|ARM64
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.UnitTests-Release|Win32.ActiveCfg = Release|Win32
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.UnitTests-Release|Win32.Build.0 = Release|Win32
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.UnitTests-Release|x64.ActiveCfg = Release|x64
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4}.UnitTests-Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -365,6 +385,7 @@ Global
 		{862B6ABA-D1C6-4DB8-A893-747CC8B5D0F2} = {09795456-9DA5-4253-AE04-DD2AB464238A}
 		{9A1D7F6C-2B48-4D5E-8C31-5F0B7E4A2D19} = {09795456-9DA5-4253-AE04-DD2AB464238A}
 		{5E3C1A74-7B26-4F0D-9A58-6C2D41E8B3AF} = {09795456-9DA5-4253-AE04-DD2AB464238A}
+		{C7F2B901-3D64-4E18-B5A7-8E0F2C6D91B4} = {09795456-9DA5-4253-AE04-DD2AB464238A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {06E89BF8-F199-48B1-94CB-D7BB1B23DDD9}

--- a/src/bufferpool.h
+++ b/src/bufferpool.h
@@ -1,0 +1,117 @@
+//  This file is part of par2cmdline (a PAR 2.0 compatible file verification and
+//  repair tool). See http://parchive.sourceforge.net for details of PAR 2.0.
+//
+//  Copyright (c) 2026 Michael Nightingale
+//
+//  par2cmdline is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  par2cmdline is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef __BUFFERPOOL_H__
+#define __BUFFERPOOL_H__
+
+#include <cassert>
+#include <condition_variable>
+#include <cstddef>
+#include <mutex>
+#include <vector>
+
+// A fixed set of equally sized buffers which the threads using them take from
+// and give back to. They all come from one allocation, so that a thread which
+// holds several of them, or every one of them, costs no more than the pool
+// does and none of them is made and thrown away as the demand for them moves.
+class BufferPool
+{
+public:
+  BufferPool()
+  : buffers(0)
+  , buffersize(0)
+  {
+  }
+
+  BufferPool(const BufferPool &) = delete;
+  BufferPool& operator=(const BufferPool &) = delete;
+
+  // Makes count buffers of size bytes, none of them in use. Every buffer taken
+  // from an earlier set is given up, so no thread may still hold one.
+  void Reset(const size_t count, const size_t size)
+  {
+    std::vector<char>(count * size).swap(slab);
+
+    buffers = count;
+    buffersize = size;
+
+    unused.clear();
+    unused.reserve(count);
+    for (size_t index = 0; index < count; ++index)
+      unused.push_back(index);
+  }
+
+  size_t Count() const {return buffers;}
+  size_t Size() const {return buffersize;}
+
+  // The buffer a taken index stands for
+  char* At(const size_t index)
+  {
+    assert(index < buffers);
+    return slab.data() + index * buffersize;
+  }
+
+  // Takes a buffer, and returns whether there was one which was not in use
+  bool TryTake(size_t &index)
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+
+    if (unused.empty())
+      return false;
+
+    index = unused.back();
+    unused.pop_back();
+
+    return true;
+  }
+
+  // Takes a buffer, waiting for one to be given back if every one of them is
+  // in use
+  size_t Take()
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+
+    given.wait(lock, [this]{return !unused.empty();});
+
+    const size_t index = unused.back();
+    unused.pop_back();
+
+    return index;
+  }
+
+  void Give(const size_t index)
+  {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      unused.push_back(index);
+    }
+
+    given.notify_one();
+  }
+
+private:
+  std::vector<char>       slab;        // every buffer, in one allocation
+  size_t                  buffers;
+  size_t                  buffersize;
+  std::vector<size_t>     unused;      // the buffers which are not in use
+  std::mutex              mutex;
+  std::condition_variable given;       // a buffer has been given back
+};
+
+#endif // __BUFFERPOOL_H__

--- a/src/bufferpool_test.cpp
+++ b/src/bufferpool_test.cpp
@@ -1,0 +1,316 @@
+//  This file is part of par2cmdline (a PAR 2.0 compatible file verification and
+//  repair tool). See http://parchive.sourceforge.net for details of PAR 2.0.
+//
+//  Copyright (c) 2026 Michael Nightingale
+//
+//  par2cmdline is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  par2cmdline is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <set>
+
+#include "libpar2internal.h"
+#include "bufferpool.h"
+
+
+// A pool hands out every buffer it was made with, and no more than that
+int test1() {
+  const size_t count = 8;
+
+  BufferPool pool;
+  pool.Reset(count, 1024);
+
+  if (pool.Count() != count || pool.Size() != 1024)
+  {
+    std::cerr << "test1: the pool is " << pool.Count() << " buffers of "
+              << pool.Size() << " bytes" << std::endl;
+    return 1;
+  }
+
+  std::set<size_t> taken;
+  for (size_t i = 0; i < count; i++)
+  {
+    size_t index;
+    if (!pool.TryTake(index))
+    {
+      std::cerr << "test1: only " << i << " of " << count << " buffers could be taken" << std::endl;
+      return 1;
+    }
+
+    if (!taken.insert(index).second)
+    {
+      std::cerr << "test1: buffer " << index << " was handed out twice" << std::endl;
+      return 1;
+    }
+  }
+
+  size_t index;
+  if (pool.TryTake(index))
+  {
+    std::cerr << "test1: a buffer was taken from a pool with none left" << std::endl;
+    return 1;
+  }
+
+  // Giving one back makes exactly one available again
+  pool.Give(*taken.begin());
+
+  if (!pool.TryTake(index))
+  {
+    std::cerr << "test1: the buffer which was given back could not be taken" << std::endl;
+    return 1;
+  }
+
+  if (pool.TryTake(index))
+  {
+    std::cerr << "test1: two buffers came back from one Give" << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
+
+
+// The buffers do not overlap, and each is the size the pool was made with
+int test2() {
+  const size_t count = 6;
+  const size_t size = 512;
+
+  BufferPool pool;
+  pool.Reset(count, size);
+
+  std::vector<size_t> taken;
+  std::vector<char*>  at;
+
+  for (size_t i = 0; i < count; i++)
+  {
+    size_t index;
+    if (!pool.TryTake(index))
+    {
+      std::cerr << "test2: only " << i << " buffers could be taken" << std::endl;
+      return 1;
+    }
+
+    taken.push_back(index);
+    at.push_back(pool.At(index));
+    memset(at.back(), (int)i + 1, size);
+  }
+
+  // Writing the whole of every buffer did not disturb any other one
+  for (size_t i = 0; i < count; i++)
+  {
+    for (size_t byte = 0; byte < size; byte++)
+    {
+      if (at[i][byte] != (char)(i + 1))
+      {
+        std::cerr << "test2: buffer " << i << " byte " << byte << " was overwritten" << std::endl;
+        return 1;
+      }
+    }
+  }
+
+  return 0;
+}
+
+
+// Take waits for a buffer when every one of them is in use
+int test3() {
+  BufferPool pool;
+  pool.Reset(1, 64);
+
+  size_t held;
+  if (!pool.TryTake(held))
+  {
+    std::cerr << "test3: the only buffer could not be taken" << std::endl;
+    return 1;
+  }
+
+  std::atomic<bool> waiting(true);
+  std::atomic<size_t> got((size_t)-1);
+
+  std::mutex mutex;
+  std::condition_variable reached;
+  bool taking = false;
+
+  std::thread taker([&] {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      taking = true;
+    }
+    reached.notify_one();
+
+    const size_t index = pool.Take();
+    got.store(index);
+    waiting.store(false);
+  });
+
+  // Wait for the other thread to be about to take, so that finding it still
+  // waiting below says that Take held it up rather than that it had yet to
+  // call Take at all
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    reached.wait(lock, [&]{ return taking; });
+  }
+
+  // The buffer is still held, so the other thread cannot have been given one
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+  if (!waiting.load())
+  {
+    std::cerr << "test3: Take returned while every buffer was in use" << std::endl;
+    taker.join();
+    return 1;
+  }
+
+  pool.Give(held);
+  taker.join();
+
+  if (got.load() != held)
+  {
+    std::cerr << "test3: Take gave buffer " << got.load() << ", expected " << held << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
+
+
+// Buffers taken and given back by many threads at once are never held twice
+int test4() {
+  const size_t count = 4;
+  const size_t threads = 8;
+  const size_t rounds = 500;
+
+  BufferPool pool;
+  pool.Reset(count, 64);
+
+  std::vector<std::atomic<int> > holders(count);
+  for (size_t i = 0; i < count; i++)
+    holders[i].store(0);
+
+  std::atomic<int> clashes(0);
+
+  std::vector<std::thread> workers;
+  for (size_t worker = 0; worker < threads; worker++)
+  {
+    workers.emplace_back([&] {
+      for (size_t round = 0; round < rounds; round++)
+      {
+        const size_t index = pool.Take();
+
+        if (holders[index].fetch_add(1) != 0)
+          clashes.fetch_add(1);
+
+        // The buffer is this thread's alone to write to
+        memset(pool.At(index), (int)(round & 0xff), pool.Size());
+
+        holders[index].fetch_sub(1);
+        pool.Give(index);
+      }
+    });
+  }
+
+  for (std::vector<std::thread>::iterator worker = workers.begin(); worker != workers.end(); ++worker)
+    worker->join();
+
+  if (clashes.load() != 0)
+  {
+    std::cerr << "test4: a buffer was held by two threads at once " << clashes.load() << " times" << std::endl;
+    return 1;
+  }
+
+  // Every buffer came back
+  for (size_t i = 0; i < count; i++)
+  {
+    size_t index;
+    if (!pool.TryTake(index))
+    {
+      std::cerr << "test4: only " << i << " of " << count << " buffers were given back" << std::endl;
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+
+// A pool can be made again with a different set of buffers
+int test5() {
+  BufferPool pool;
+
+  pool.Reset(2, 128);
+
+  size_t index;
+  if (!pool.TryTake(index))
+  {
+    std::cerr << "test5: the first set of buffers could not be taken" << std::endl;
+    return 1;
+  }
+
+  pool.Reset(5, 32);
+
+  if (pool.Count() != 5 || pool.Size() != 32)
+  {
+    std::cerr << "test5: the pool is " << pool.Count() << " buffers of "
+              << pool.Size() << " bytes" << std::endl;
+    return 1;
+  }
+
+  for (size_t i = 0; i < 5; i++)
+  {
+    if (!pool.TryTake(index))
+    {
+      std::cerr << "test5: only " << i << " of the new buffers could be taken" << std::endl;
+      return 1;
+    }
+  }
+
+  if (pool.TryTake(index))
+  {
+    std::cerr << "test5: a buffer was taken from a pool with none left" << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
+
+
+int main() {
+  if (test1()) {
+    std::cerr << "FAILED: test1" << std::endl;
+    return 1;
+  }
+  if (test2()) {
+    std::cerr << "FAILED: test2" << std::endl;
+    return 1;
+  }
+  if (test3()) {
+    std::cerr << "FAILED: test3" << std::endl;
+    return 1;
+  }
+  if (test4()) {
+    std::cerr << "FAILED: test4" << std::endl;
+    return 1;
+  }
+  if (test5()) {
+    std::cerr << "FAILED: test5" << std::endl;
+    return 1;
+  }
+
+  std::cout << "SUCCESS: bufferpool_test complete." << std::endl;
+
+  return 0;
+}

--- a/src/libpar2internal.h
+++ b/src/libpar2internal.h
@@ -245,6 +245,7 @@ private:
 
 #include "letype.h"
 #include "foreach_parallel.h"
+#include "bufferpool.h"
 #include "taskpool.h"
 #include "progressmeter.h"
 

--- a/src/libpar2internal.h
+++ b/src/libpar2internal.h
@@ -245,6 +245,7 @@ private:
 
 #include "letype.h"
 #include "foreach_parallel.h"
+#include "taskpool.h"
 #include "progressmeter.h"
 
 #include "galois.h"

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -156,8 +156,9 @@ Result Par2Repairer::Process(
   // Set the number of threads
   totalthreads = resolve_threads(nthreads);
 
-  // No more files are read at once than there are threads to hash them with
-  filethreads = std::min(_filethreads, totalthreads);
+  // No more files are read at once than there are threads to hash them with,
+  // and never none whatever the caller asked for
+  filethreads = std::max(1u, std::min(_filethreads, totalthreads));
 
   // Determine the searchpath from the location of the main PAR2 file
   std::string name;

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -20,6 +20,8 @@
 
 #include "libpar2internal.h"
 
+#include <functional>
+
 #ifdef _MSC_VER
 #ifdef _DEBUG
 #undef THIS_FILE
@@ -53,7 +55,8 @@ Par2Repairer::Par2Repairer(std::ostream &sout, std::ostream &serr, const NoiseLe
 , basepath()
 , totalthreads(default_threads())
 , filethreads(_FILE_THREADS)
-, blockthreads(1)
+, blockpool()
+, activereaders(0)
 , setid()
 , recoverypacketmap()
 , diskFileMap()
@@ -205,6 +208,8 @@ Result Par2Repairer::Process(
   if (!ComputeWindowTable())
     return eLogicError;
 
+  ResetScanBuffers(std::max(sourcefiles.size(), extrafiles.size()));
+
   // Attempt to verify all of the source files
   if (!VerifySourceFiles(basepath, extrafiles))
     return eFileIOError;
@@ -218,6 +223,10 @@ Result Par2Repairer::Process(
 
   // Find out how much data we have found
   UpdateVerificationResults();
+
+  // Nothing is scanned again until the repaired files are verified, so the
+  // buffers are given up rather than held against the memory a repair needs
+  scanbuffers.Reset(0, 0);
 
   if (noiselevel > nlSilent)
     sout << '\n';
@@ -293,7 +302,16 @@ Result Par2Repairer::Process(
         if (noiselevel > nlSilent)
           sout << "\nVerifying repaired files:\n" << std::endl;
 
+        // The repaired files are scanned into buffers of their own, so the ones
+        // the repair read and wrote through are given up first
+        delete [] (u8*)inputbuffer;
+        inputbuffer = 0;
+        delete [] (u8*)outputbuffer;
+        outputbuffer = 0;
+
         // Verify that all of the reconstructed target files are now correct
+        ResetScanBuffers(verifylist.size());
+
         if (!VerifyTargetFiles(basepath))
         {
           // Delete all of the partly reconstructed files
@@ -1208,7 +1226,7 @@ bool Par2Repairer::VerifySourceFiles(const std::string& basepath, std::vector<st
   ProgressMeter<u64> progress(sout, "Scanning: ", mttotalsize);
 
   // Start verifying the files
-  foreach_parallel(sortedfiles, SetBlockThreads(sortedfiles.size()), [&](Par2RepairerSourceFile *sourcefile)
+  foreach_parallel(sortedfiles, FileThreads(sortedfiles.size()), [&](Par2RepairerSourceFile *sourcefile)
   {
     // What filename does the file use
     const std::string& file = sourcefile->TargetFileName();
@@ -1314,7 +1332,7 @@ bool Par2Repairer::VerifyExtraFiles(const std::vector<std::string> &extrafiles, 
 
     ProgressMeter<u64> progress(sout, "Scanning: ", mttotalextrasize);
 
-    foreach_parallel(extrafiles, SetBlockThreads(extrafiles.size()), [&](const std::string &extrafile)
+    foreach_parallel(extrafiles, FileThreads(extrafiles.size()), [&](const std::string &extrafile)
     {
       std::string filename = extrafile;
 
@@ -1567,61 +1585,63 @@ bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [i
   if (0 == blockcount)
     return false;
 
-  const u32 workers = blockthreads;
-
   // A single thread gains nothing from checking the blocks up front, and a
   // damaged file would then be read a second time by the scan below
-  if (workers < 2)
+  if (!blockpool || blockpool->ThreadCount() < 2
+      || scanbuffers.Count() < 2 || scanbuffers.Size() < blocksize)
     return false;
 
   matched.assign(blockcount, 0);
 
-  // One block for each thread is read at a time, into one of two buffers, so
-  // that the next batch can be read while the current one is being checked
-  const u32 batchblocks = workers;
-
-  std::vector<char> buffer[2];
-  buffer[0].resize((size_t)batchblocks * blocksize);
-  buffer[1].resize((size_t)batchblocks * blocksize);
-
-  std::atomic<bool> readfailed(false);
+  // The files being scanned at once share the pool's threads and the buffers
+  // they read into, so a file left scanning on its own reads as far ahead as
+  // the whole pool can keep up with
+  struct ActiveReader
+  {
+    explicit ActiveReader(std::atomic<u32> &count) : count(count) {++count;}
+    ~ActiveReader(void) {--count;}
+    std::atomic<u32> &count;
+  } active(activereaders);
 
   FileHasher filehasher(fullhash);
+
+  const size_t slots = scanbuffers.Count();
+  const u32    batchblocks = (u32)(scanbuffers.Size() / blocksize);
+
+  std::unique_ptr<TaskPool::Batch[]> batches(new TaskPool::Batch[slots]);
 
   // The blocks of a batch are next to each other, so they are read in one go.
   // Only the last block of a file can be short, and its entry covers it padded
   // out to the full block size with zeroes
-  auto readbatch = [&](u32 firstblock, std::vector<char> &into)
+  auto readbatch = [&](char *into, const u32 first, const u32 blocks)
   {
-    const u32 blocks = std::min(firstblock + batchblocks, blockcount) - firstblock;
-    const u64 offset = static_cast<u64>(firstblock) * blocksize;
+    const u64 offset = static_cast<u64>(first) * blocksize;
     const size_t span = static_cast<size_t>(blocks) * blocksize;
-    const size_t length = std::min(static_cast<u64>(span), filesize - offset);
+    const size_t length = (size_t)std::min(static_cast<u64>(span), filesize - offset);
 
-    if (!diskfile->Read(offset, &into[0], length))
-    {
-      readfailed = true;
-      return;
-    }
+    if (!diskfile->Read(offset, into, length))
+      return false;
 
-    filehasher.Update(offset, &into[0], length);
+    filehasher.Update(offset, into, length);
 
     if (length < span)
       memset(&into[length], 0, span - length);
+
+    return true;
   };
 
-  auto checkblock = [&](const u32 block, const std::vector<char> &checking, u32 firstblock)
+  auto checkblock = [&](const char *from, const u32 first, const u32 block)
   {
     const u64 length = std::min(blocksize, filesize - static_cast<u64>(block) * blocksize);
-    const char *at = &checking[static_cast<size_t>(block - firstblock) * blocksize];
+    const char *data = &from[static_cast<size_t>(block - first) * blocksize];
     const FILEVERIFICATIONENTRY *entry = verificationpacket->VerificationEntry(block);
 
-    const u32 checksum = ~0 ^ CRCUpdateBlock(~0, blocksize, at);
+    const u32 checksum = ~0 ^ CRCUpdateBlock(~0, blocksize, data);
     if (checksum != entry->crc)
       return;
 
     MD5Context context;
-    context.Update(at, blocksize);
+    context.Update(data, blocksize);
 
     MD5Hash hash{};
     context.Final(hash);
@@ -1635,87 +1655,134 @@ bool Par2Repairer::ScanDataFileAligned(DiskFile               *diskfile,   // [i
       progress.Add(length);
   };
 
-  // Checkers take the blocks of a batch claimblocks at a time. One block each
-  // is what the batch holds today; a hasher that takes several blocks at once
-  // would ask for more.
-  const u32 claimblocks = 1;
-  const u32 batchcount = (blockcount + batchblocks - 1) / batchblocks;
-
-  std::mutex mutex;
-  std::condition_variable batchfilled;   // the reader has filled a buffer
-  std::condition_variable batchchecked;  // the checkers have emptied one
-  u32 filledbatches = 0;                 // batches the reader has completed
-  u32 outstanding[2] = { 0, 0 };         // blocks left to check in each buffer
-  std::atomic<u32> nextblock(0);      // the next block a checker may claim
-
-  // Reads each batch into the buffer the checkers are not using, so that the
-  // next batch arrives while the current one is being hashed
-  std::thread reader([&] {
-    for (u32 batch = 0; batch < batchcount; ++batch)
-    {
-      const u32 firstblock = batch * batchblocks;
-      const u32 blocks = std::min(firstblock + batchblocks, blockcount) - firstblock;
-
-      {
-        std::unique_lock<std::mutex> lock(mutex);
-        batchchecked.wait(lock, [&]{ return outstanding[batch % 2] == 0; });
-      }
-
-      readbatch(firstblock, buffer[batch % 2]);
-
-      {
-        std::lock_guard<std::mutex> lock(mutex);
-        outstanding[batch % 2] = blocks;
-        filledbatches = batch + 1;
-      }
-      batchfilled.notify_all();
-
-      if (readfailed)
-        return;
-    }
-  });
-
-  std::vector<std::thread> checkers;
-  checkers.reserve(workers);
-  for (u32 worker = 0; worker < workers; ++worker)
+  // What each batch which has been given to the pool is checking. The pool
+  // takes its blocks one at a time, alongside the blocks of every other file
+  // being scanned.
+  struct Slot
   {
-    checkers.emplace_back([&]()
-    {
-      for (;;)
-      {
-        const u32 firstclaimed = nextblock.fetch_add(claimblocks);
-        if (firstclaimed >= blockcount)
-          return;
+    decltype(&checkblock) check;
+    BufferPool           *buffers;
+    size_t                held;   // the buffer it read into
+    u32                   first;
 
-        // A claim never spans two batches, because each batch sits in its own buffer
-        const u32 batch = firstclaimed / batchblocks;
-        const u32 lastclaimed = std::min(firstclaimed + claimblocks,
-                                         std::min((batch + 1) * batchblocks, blockcount));
+    void operator()(const size_t block) const
+      {(*check)(buffers->At(held), first, (u32)block);}
+  };
 
-        {
-          std::unique_lock<std::mutex> lock(mutex);
-          batchfilled.wait(lock, [&]{ return filledbatches > batch || readfailed; });
-        }
-
-        if (readfailed)
-          return;
-
-        for (u32 block = firstclaimed; block < lastclaimed; ++block)
-          checkblock(block, buffer[batch % 2], batch * batchblocks);
-
-        {
-          std::lock_guard<std::mutex> lock(mutex);
-          outstanding[batch % 2] -= lastclaimed - firstclaimed;
-          if (outstanding[batch % 2] == 0)
-            batchchecked.notify_one();
-        }
-      }
-    });
+  std::vector<Slot> slot(slots);
+  for (size_t s = 0; s < slots; ++s)
+  {
+    slot[s].check = &checkblock;
+    slot[s].buffers = &scanbuffers;
   }
 
-  reader.join();
-  for (auto & checker : checkers)
-    checker.join();
+  bool readfailed = false;
+  u32  nextblock = 0;
+
+  size_t next = 0;         // the slot the next batch is given
+  size_t oldest = 0;       // the slot of the batch which has been out longest
+  size_t outstanding = 0;
+
+  // Waits for the batch which has been with the pool longest, helping to check
+  // it, and gives back the buffer it was reading from
+  const std::function<void(void)> retire = [&]()
+  {
+    blockpool->Wait(batches[oldest]);
+    scanbuffers.Give(slot[oldest].held);
+
+    oldest = (oldest + 1) % slots;
+    --outstanding;
+  };
+
+  // The pool has to be finished with every batch before the buffers and the
+  // state the batches point at go away, whichever way the scan is left. This
+  // is declared last so that it runs before any of them.
+  struct Drain
+  {
+    const std::function<void(void)> *retire;
+    const size_t                    *outstanding;
+
+    ~Drain(void)
+    {
+      while (*outstanding > 0)
+      {
+        try
+        {
+          (*retire)();
+        }
+        catch (...)
+        {
+          // A batch which failed still has to be waited for, and the buffer
+          // it was reading into still has to be given back
+        }
+      }
+    }
+  } drain{&retire, &outstanding};
+
+  while (nextblock < blockcount)
+  {
+    // A file keeps to its share of the buffers while others are being read,
+    // and takes back the oldest of its own rather than waiting on them
+    const size_t share = std::max<size_t>(2, slots / std::max(1u, activereaders.load()));
+
+    size_t buffer = 0;
+
+    for (;;)
+    {
+      // Over its share, this file takes back one of its own before it may
+      // read any further ahead
+      if (outstanding >= share)
+      {
+        retire();
+        continue;
+      }
+
+      if (scanbuffers.TryTake(buffer))
+        break;
+
+      // Every buffer is with another file. Waiting for this file's own oldest
+      // batch keeps it from waiting on the files it is sharing them with,
+      // which it has to do only when it has no batch of its own to take back
+      if (0 == outstanding)
+      {
+        buffer = scanbuffers.Take();
+        break;
+      }
+
+      retire();
+    }
+
+    const u32 blocks = std::min(batchblocks, blockcount - nextblock);
+
+    slot[next].held = buffer;
+    slot[next].first = nextblock;
+
+    // The buffer is the pool's to give back only once the batch reading into
+    // it has been submitted
+    try
+    {
+      if (!readbatch(scanbuffers.At(buffer), nextblock, blocks))
+      {
+        scanbuffers.Give(buffer);
+        readfailed = true;
+        break;
+      }
+
+      blockpool->Submit(batches[next], nextblock, nextblock + blocks, slot[next]);
+    }
+    catch (...)
+    {
+      scanbuffers.Give(buffer);
+      throw;
+    }
+
+    next = (next + 1) % slots;
+    ++outstanding;
+    nextblock += blocks;
+  }
+
+  while (outstanding > 0)
+    retire();
 
   if (readfailed)
     return false;
@@ -2662,6 +2729,36 @@ bool Par2Repairer::ComputeRSmatrix(void)
   return success;
 }
 
+// The files being read take the buffers they read into from these, which
+// between them hold two batches for each of the filecount files which may be
+// read at once
+void Par2Repairer::ResetScanBuffers(const size_t filecount)
+{
+  // The blocks of a file are only checked where they are expected to be when
+  // there are verification packets to check them against and more than one
+  // thread to do it with, so otherwise nothing would ever be read into them
+  if (!blockverifiable || totalthreads < 2)
+  {
+    scanbuffers.Reset(0, 0);
+    return;
+  }
+
+  // Every file being read shares these threads to check its blocks with
+  if (!blockpool)
+    blockpool.reset(new TaskPool(totalthreads));
+
+  if (blockpool->ThreadCount() < 2)
+  {
+    scanbuffers.Reset(0, 0);
+    return;
+  }
+
+  const u32 readers = FileThreads(filecount);
+
+  scanbuffers.Reset(2 * readers,
+                    (size_t)std::max(1u, totalthreads / readers) * (size_t)blocksize);
+}
+
 // Allocate memory buffers for reading and writing data to disk.
 bool Par2Repairer::AllocateBuffers(size_t memorylimit)
 {
@@ -2869,7 +2966,7 @@ bool Par2Repairer::VerifyTargetFiles(const std::string &basepath)
   ProgressMeter<u64> progress(sout, "Scanning: ", mttotalsize);
 
   // Iterate through each file in the verification list
-  foreach_parallel(verifylist, SetBlockThreads(verifylist.size()), [&](Par2RepairerSourceFile *sourcefile)
+  foreach_parallel(verifylist, FileThreads(verifylist.size()), [&](Par2RepairerSourceFile *sourcefile)
   {
     DiskFile *targetfile = sourcefile->GetTargetFile();
 

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -2731,7 +2731,8 @@ bool Par2Repairer::ComputeRSmatrix(void)
 
 // The files being read take the buffers they read into from these, which
 // between them hold two batches for each of the filecount files which may be
-// read at once
+// read at once. A batch is a whole number of blocks, at least one, and no more
+// than MAX_CHUNK_SIZE unless a single block is already larger than that.
 void Par2Repairer::ResetScanBuffers(const size_t filecount)
 {
   // The blocks of a file are only checked where they are expected to be when
@@ -2755,8 +2756,12 @@ void Par2Repairer::ResetScanBuffers(const size_t filecount)
 
   const u32 readers = FileThreads(filecount);
 
-  scanbuffers.Reset(2 * readers,
-                    (size_t)std::max(1u, totalthreads / readers) * (size_t)blocksize);
+  const size_t batchsize = (size_t)std::max(1u, totalthreads / readers) * (size_t)blocksize;
+  const size_t maxbatchsize = MAX_CHUNK_SIZE != 0
+    ? std::max((size_t)blocksize, (size_t)MAX_CHUNK_SIZE)
+    : batchsize;
+
+  scanbuffers.Reset(2 * readers, std::min(batchsize, maxbatchsize));
 }
 
 // Allocate memory buffers for reading and writing data to disk.

--- a/src/par2repairer.h
+++ b/src/par2repairer.h
@@ -156,17 +156,14 @@ protected:
   bool RemoveBackupFiles(void);
   bool RemoveParFiles(void);
 
+  // Make the buffers the files being scanned read into, or give them up when
+  // no file will have its blocks checked where they are expected to be
+  void ResetScanBuffers(const size_t filecount);
+
+  // The number of files to read at once, which is what limits how many are
+  // open at a time rather than how much of the work they get
   u32                                 FileThreads(size_t filecount) const
     {return (u32)std::max<size_t>(1, std::min<size_t>(filethreads, filecount));}
-
-  // Divides the threads between the files scanned at once and the blocks
-  // checked within one file. Returns the number of files to scan at once.
-  u32                                 SetBlockThreads(size_t filecount)
-    {
-      const u32 files = FileThreads(filecount);
-      blockthreads = std::max(1u, totalthreads / files);
-      return files;
-    }
 
 protected:
   std::ostream &sout; // stream for output (for commandline, this is cout)
@@ -179,8 +176,13 @@ protected:
   std::string               basepath;
 
   u32 totalthreads;            // Number of threads the whole repair may use
-  u32 filethreads;             // Number of threads for file processing
-  u32 blockthreads;            // Number of threads left to check one file's blocks
+  u32 filethreads;             // Number of files to read at once
+
+  // The threads which check the blocks of every file being read, the buffers
+  // those files read into, and how many files are being read at the moment
+  std::unique_ptr<TaskPool> blockpool;
+  BufferPool                scanbuffers;
+  std::atomic<u32>          activereaders;
 
   bool                      skipdata;                // Should we skip data whilst scanning
   u64                       skipleaway;              // The leaway +/- we should allow whilst scanning

--- a/src/taskpool.h
+++ b/src/taskpool.h
@@ -1,0 +1,247 @@
+//  This file is part of par2cmdline (a PAR 2.0 compatible file verification and
+//  repair tool). See http://parchive.sourceforge.net for details of PAR 2.0.
+//
+//  Copyright (c) 2026 Michael Nightingale
+//
+//  par2cmdline is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  par2cmdline is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef __TASKPOOL_H__
+#define __TASKPOOL_H__
+
+#include <algorithm>
+#include <condition_variable>
+#include <cstddef>
+#include <deque>
+#include <exception>
+#include <mutex>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+// A fixed set of threads which run work submitted to them from anywhere, so
+// that work submitted from several places at once is shared out between all of
+// them rather than each place being given a share of the threads.
+//
+// Submitting does not wait for the work to run, and a thread which waits for
+// a submission of its own runs queued work while it waits. The pool's own
+// threads wait for nothing but the queue, so a thread which is waiting for its
+// work can never leave the queue unattended.
+class TaskPool
+{
+public:
+  // One submission of work. The thread which submits it owns it, and must keep
+  // both it and the body it was given alive until Wait has returned.
+  class Batch
+  {
+    friend class TaskPool;
+
+  public:
+    Batch()
+    : fn(nullptr)
+    , call(nullptr)
+    , next(0)
+    , end(0)
+    , remaining(0) {
+    }
+
+    Batch(const Batch &) = delete;
+    Batch& operator=(const Batch &) = delete;
+
+  private:
+    void  *fn;                              // the body, held without owning it
+    void (*call)(void *fn, size_t value);   // calls the body for one value
+    size_t next;                            // the next value a thread may claim
+    size_t end;                             // one past the last value to run
+    size_t remaining;                       // values which have not finished
+    std::exception_ptr error;               // the first failure of the body
+  };
+
+  explicit TaskPool(const size_t numthreads)
+  : stopping(false) {
+    const size_t wanted = std::max<size_t>(1, numthreads);
+    threads.reserve(wanted);
+
+    for (size_t i = 0; i < wanted; ++i)
+    {
+      try
+      {
+        threads.emplace_back(&TaskPool::Serve, this);
+      }
+      catch (const std::system_error &)
+      {
+        // The work runs on however many threads could be started, and on the
+        // threads waiting for it
+        break;
+      }
+    }
+  }
+
+  ~TaskPool()
+  {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      stopping = true;
+    }
+    haswork.notify_all();
+
+    for (auto & thread : threads)
+      thread.join();
+  }
+
+  TaskPool(const TaskPool &) = delete;
+  TaskPool& operator=(const TaskPool &) = delete;
+
+  size_t ThreadCount() const {return threads.size();}
+
+  // Queues fn to be called for every value in [first, last) and returns
+  // without waiting for any of them to run. The batch must be handed to Wait
+  // before either it or fn goes away.
+  template<typename Fn>
+  void Submit(Batch &batch, const size_t first, const size_t last, Fn &fn)
+  {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+
+      batch.fn = &fn;
+      batch.call = &Invoke<Fn>;
+      batch.next = first;
+      batch.end = last;
+      batch.remaining = last > first ? last - first : 0;
+      batch.error = std::exception_ptr();
+
+      if (batch.remaining == 0)
+        return;
+
+      queue.push_back(&batch);
+    }
+
+    haswork.notify_all();
+
+    // A thread waiting for a batch of its own runs whatever is queued while it
+    // waits, so it is woken for this one as well as the pool's own threads
+    batchdone.notify_all();
+  }
+
+  // Runs queued work until the batch has finished. An exception thrown by the
+  // body abandons the rest of that batch and is rethrown here.
+  void Wait(Batch &batch)
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+
+    while (batch.remaining != 0)
+    {
+      // Nothing is left to help with when every value has been claimed, and
+      // whichever threads hold those claims will finish them
+      if (!Claim(lock))
+        batchdone.wait(lock);
+    }
+
+    if (batch.error)
+    {
+      const std::exception_ptr failure = batch.error;
+      batch.error = std::exception_ptr();
+      std::rethrow_exception(failure);
+    }
+  }
+
+private:
+  template<typename Fn>
+  static void Invoke(void *fn, const size_t value)
+  {
+    (*static_cast<Fn *>(fn))(value);
+  }
+
+  void Serve()
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+
+    for (;;)
+    {
+      haswork.wait(lock, [this]{ return stopping || !queue.empty(); });
+
+      if (stopping)
+        return;
+
+      Claim(lock);
+    }
+  }
+
+  // Runs one value of the batch at the head of the queue and returns whether
+  // there was one. Called with the lock held, which is dropped while the body
+  // runs and held again on return.
+  bool Claim(std::unique_lock<std::mutex> &lock)
+  {
+    if (queue.empty())
+      return false;
+
+    Batch *batch = queue.front();
+    const size_t value = batch->next++;
+
+    // A batch is queued only while it has values left for a thread to claim
+    if (batch->next == batch->end)
+      queue.pop_front();
+
+    lock.unlock();
+
+    std::exception_ptr failure;
+
+    try
+    {
+      batch->call(batch->fn, value);
+    }
+    catch (...)
+    {
+      failure = std::current_exception();
+    }
+
+    lock.lock();
+
+    if (failure)
+    {
+      if (!batch->error)
+        batch->error = failure;
+
+      Abandon(batch);
+    }
+
+    if (--batch->remaining == 0)
+      batchdone.notify_all();
+
+    return true;
+  }
+
+  // Drops the values of a failed batch which no thread has claimed yet
+  void Abandon(Batch *batch)
+  {
+    if (batch->next == batch->end)
+      return;
+
+    const auto queued = std::find(queue.begin(), queue.end(), batch);
+    if (queued != queue.end())
+      queue.erase(queued);
+
+    batch->remaining -= batch->end - batch->next;
+    batch->next = batch->end;
+  }
+
+  std::vector<std::thread> threads;
+  std::deque<Batch*>       queue;      // batches with values left to claim
+  bool                     stopping;
+  std::mutex               mutex;
+  std::condition_variable  haswork;    // a batch has been queued
+  std::condition_variable  batchdone;  // a batch has finished
+};
+
+#endif // __TASKPOOL_H__

--- a/src/taskpool_test.cpp
+++ b/src/taskpool_test.cpp
@@ -1,0 +1,362 @@
+//  This file is part of par2cmdline (a PAR 2.0 compatible file verification and
+//  repair tool). See http://parchive.sourceforge.net for details of PAR 2.0.
+//
+//  Copyright (c) 2026 Michael Nightingale
+//
+//  par2cmdline is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  par2cmdline is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+#include <chrono>
+#include <iostream>
+#include <stdexcept>
+
+#include "libpar2internal.h"
+#include "taskpool.h"
+
+
+// Counts how many times each value in [first, last) was run, and reports any
+// value which was not run exactly once
+static int check_counts(const char *what,
+                        const std::vector<std::atomic<int> > &counts,
+                        size_t first,
+                        size_t last)
+{
+  for (size_t i = 0; i < counts.size(); i++)
+  {
+    const int expected = (i >= first && i < last) ? 1 : 0;
+    if (counts[i].load() != expected)
+    {
+      std::cerr << what << ": value " << i << " ran " << counts[i].load()
+                << " times, expected " << expected << std::endl;
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+
+// Every value of a batch runs exactly once, whatever the thread count
+int test1() {
+  const size_t size = 1000;
+
+  for (u32 numthreads = 1; numthreads <= 8; numthreads++)
+  {
+    std::vector<std::atomic<int> > counts(size);
+    for (size_t i = 0; i < size; i++)
+      counts[i].store(0);
+
+    TaskPool pool(numthreads);
+
+    auto body = [&](size_t value) { counts[value].fetch_add(1); };
+
+    TaskPool::Batch batch;
+    pool.Submit(batch, 0, size, body);
+    pool.Wait(batch);
+
+    if (check_counts("test1", counts, 0, size))
+      return 1;
+  }
+
+  return 0;
+}
+
+
+// Only the values of the range asked for are run
+int test2() {
+  const size_t size = 64;
+
+  std::vector<std::atomic<int> > counts(size);
+  for (size_t i = 0; i < size; i++)
+    counts[i].store(0);
+
+  TaskPool pool(4);
+
+  auto body = [&](size_t value) { counts[value].fetch_add(1); };
+
+  TaskPool::Batch batch;
+  pool.Submit(batch, 16, 48, body);
+  pool.Wait(batch);
+
+  return check_counts("test2", counts, 16, 48);
+}
+
+
+// An empty range finishes without running anything
+int test3() {
+  TaskPool pool(4);
+
+  std::atomic<int> runs(0);
+  auto body = [&](size_t) { runs.fetch_add(1); };
+
+  TaskPool::Batch batch;
+
+  pool.Submit(batch, 2, 2, body);
+  pool.Wait(batch);
+
+  pool.Submit(batch, 3, 1, body);
+  pool.Wait(batch);
+
+  if (runs.load() != 0)
+  {
+    std::cerr << "test3: an empty range ran " << runs.load() << " values" << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
+
+
+// A batch can be submitted again once it has been waited for
+int test4() {
+  const size_t size = 100;
+  const int rounds = 20;
+
+  std::vector<std::atomic<int> > counts(size);
+  for (size_t i = 0; i < size; i++)
+    counts[i].store(0);
+
+  TaskPool pool(4);
+
+  auto body = [&](size_t value) { counts[value].fetch_add(1); };
+
+  TaskPool::Batch batch;
+
+  for (int round = 0; round < rounds; round++)
+  {
+    pool.Submit(batch, 0, size, body);
+    pool.Wait(batch);
+  }
+
+  for (size_t i = 0; i < size; i++)
+  {
+    if (counts[i].load() != rounds)
+    {
+      std::cerr << "test4: value " << i << " ran " << counts[i].load()
+                << " times, expected " << rounds << std::endl;
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+
+// Work submitted from many threads at once is shared between them all, even
+// when there are more threads submitting than the pool has
+int test5() {
+  const size_t submitters = 8;
+  const size_t size = 500;
+
+  for (u32 numthreads = 1; numthreads <= 4; numthreads++)
+  {
+    std::vector<std::atomic<int> > counts(submitters * size);
+    for (size_t i = 0; i < counts.size(); i++)
+      counts[i].store(0);
+
+    TaskPool pool(numthreads);
+
+    std::vector<std::thread> threads;
+    for (size_t submitter = 0; submitter < submitters; submitter++)
+    {
+      threads.emplace_back([&, submitter] {
+        auto body = [&](size_t value) { counts[value].fetch_add(1); };
+
+        TaskPool::Batch batch;
+        pool.Submit(batch, submitter * size, (submitter + 1) * size, body);
+        pool.Wait(batch);
+      });
+    }
+
+    for (std::vector<std::thread>::iterator thread = threads.begin(); thread != threads.end(); ++thread)
+      thread->join();
+
+    if (check_counts("test5", counts, 0, counts.size()))
+      return 1;
+  }
+
+  return 0;
+}
+
+
+// A thread waiting for its own batch runs the work which is still queued, so
+// two values which have to run at the same time can, even on a pool of one
+int test6() {
+  TaskPool pool(1);
+
+  // The work can only be shared with the thread waiting for it if the pool
+  // managed to start a thread of its own
+  if (pool.ThreadCount() < 1)
+    return 0;
+
+  std::mutex mutex;
+  std::condition_variable arrived;
+  int waiting = 0;
+  bool timedout = false;
+
+  auto body = [&](size_t) {
+    std::unique_lock<std::mutex> lock(mutex);
+
+    if (++waiting == 2)
+    {
+      arrived.notify_all();
+      return;
+    }
+
+    if (!arrived.wait_for(lock, std::chrono::seconds(30), [&]{ return waiting == 2; }))
+    {
+      // Let the other value out rather than leaving the test hanging
+      timedout = true;
+      waiting = 2;
+      arrived.notify_all();
+    }
+  };
+
+  TaskPool::Batch batch;
+  pool.Submit(batch, 0, 2, body);
+  pool.Wait(batch);
+
+  if (timedout)
+  {
+    std::cerr << "test6: the thread waiting for the batch did not run any of it" << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
+
+
+// A failure of the body is rethrown by Wait, which still returns once every
+// value the batch had out has finished
+//
+// How many values run before the failure is recorded is not fixed: the threads
+// which have already claimed one run it whatever happens, so only the values
+// no thread had reached are abandoned. What is checked here is that the batch
+// finishes rather than hanging, which is what wrong accounting in Abandon
+// would cost, and that it is left fit to be submitted again.
+int test7() {
+  const size_t size = 200;
+
+  for (u32 numthreads = 1; numthreads <= 4; numthreads++)
+  {
+    TaskPool pool(numthreads);
+
+    std::atomic<int> runs(0);
+    auto body = [&](size_t value) {
+      runs.fetch_add(1);
+      if (value == 0)
+        throw std::runtime_error("failed");
+    };
+
+    TaskPool::Batch batch;
+    pool.Submit(batch, 0, size, body);
+
+    bool caught = false;
+    try
+    {
+      pool.Wait(batch);
+    }
+    catch (const std::runtime_error &)
+    {
+      caught = true;
+    }
+
+    if (!caught)
+    {
+      std::cerr << "test7: the failure was not rethrown" << std::endl;
+      return 1;
+    }
+
+    // The batch is usable again, and no longer holds the failure
+    runs.store(0);
+    auto clean = [&](size_t) { runs.fetch_add(1); };
+    pool.Submit(batch, 0, 10, clean);
+    pool.Wait(batch);
+
+    if (runs.load() != 10)
+    {
+      std::cerr << "test7: " << runs.load() << " values ran after the failure, expected 10" << std::endl;
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+
+// Several batches from one thread can be in flight at once, and each is waited
+// for on its own
+int test8() {
+  const size_t size = 200;
+
+  std::vector<std::atomic<int> > counts(2 * size);
+  for (size_t i = 0; i < counts.size(); i++)
+    counts[i].store(0);
+
+  TaskPool pool(4);
+
+  auto body = [&](size_t value) { counts[value].fetch_add(1); };
+
+  TaskPool::Batch first;
+  TaskPool::Batch second;
+
+  pool.Submit(first, 0, size, body);
+  pool.Submit(second, size, 2 * size, body);
+
+  pool.Wait(second);
+  pool.Wait(first);
+
+  return check_counts("test8", counts, 0, counts.size());
+}
+
+
+int main() {
+  if (test1()) {
+    std::cerr << "FAILED: test1" << std::endl;
+    return 1;
+  }
+  if (test2()) {
+    std::cerr << "FAILED: test2" << std::endl;
+    return 1;
+  }
+  if (test3()) {
+    std::cerr << "FAILED: test3" << std::endl;
+    return 1;
+  }
+  if (test4()) {
+    std::cerr << "FAILED: test4" << std::endl;
+    return 1;
+  }
+  if (test5()) {
+    std::cerr << "FAILED: test5" << std::endl;
+    return 1;
+  }
+  if (test6()) {
+    std::cerr << "FAILED: test6" << std::endl;
+    return 1;
+  }
+  if (test7()) {
+    std::cerr << "FAILED: test7" << std::endl;
+    return 1;
+  }
+  if (test8()) {
+    std::cerr << "FAILED: test8" << std::endl;
+    return 1;
+  }
+
+  std::cout << "SUCCESS: taskpool_test complete." << std::endl;
+
+  return 0;
+}

--- a/tests/bufferpool_test.vcxproj
+++ b/tests/bufferpool_test.vcxproj
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{c7f2b901-3d64-4e18-b5a7-8e0f2c6d91b4}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="..\par2cmdline.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\bufferpool_test.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\libpar2.vcxproj">
+      <Project>{d0a94f83-495e-4fb2-ac33-9a3ec2cc263b}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\src\bufferpool.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/tests/build_unit_tests.ps1
+++ b/tests/build_unit_tests.ps1
@@ -39,6 +39,7 @@ if ($Clean) {
         "criticalpacket_test",
         "reedsolomon_test",
         "galois_test",
+        "taskpool_test",
         "utf8_test"
     )
     $ObjDir = Join-Path $script:RootDir "tests\$Platform\$Configuration"

--- a/tests/build_unit_tests.ps1
+++ b/tests/build_unit_tests.ps1
@@ -40,6 +40,7 @@ if ($Clean) {
         "reedsolomon_test",
         "galois_test",
         "taskpool_test",
+        "bufferpool_test",
         "utf8_test"
     )
     $ObjDir = Join-Path $script:RootDir "tests\$Platform\$Configuration"

--- a/tests/taskpool_test.vcxproj
+++ b/tests/taskpool_test.vcxproj
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{5e3c1a74-7b26-4f0d-9a58-6c2d41e8b3af}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="..\par2cmdline.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\taskpool_test.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\libpar2.vcxproj">
+      <Project>{d0a94f83-495e-4fb2-ac33-9a3ec2cc263b}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\src\taskpool.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/tests/unit_tests.ps1
+++ b/tests/unit_tests.ps1
@@ -48,6 +48,7 @@ $unitTestExes = @(
     "criticalpacket_test.exe",
     "reedsolomon_test.exe",
     "galois_test.exe",
+    "taskpool_test.exe",
     "utf8_test.exe"
 )
 

--- a/tests/unit_tests.ps1
+++ b/tests/unit_tests.ps1
@@ -49,6 +49,7 @@ $unitTestExes = @(
     "reedsolomon_test.exe",
     "galois_test.exe",
     "taskpool_test.exe",
+    "bufferpool_test.exe",
     "utf8_test.exe"
 )
 


### PR DESCRIPTION
Each file being read used to get a fixed share of the `-t` threads to check its blocks with, handed out by `SetBlockThreads`. That share is gone. One `TaskPool` of `-t` threads is built once and every file submits its block checks into it. Buffers come from a `BufferPool` of `2 * -T` fixed slots in a single allocation, given back before a repair allocates against `-m`.

The threads reading files stay off the pool, and a reader waiting for its own batch runs whatever else is queued while it waits.

`-T` now only caps how many files are read at once, and is clamped to at least one.

## Why

A static split leaves threads idle. Whichever file finishes first takes its share out of use for the rest of the scan, and when more files are read at once than there are threads (`-T8 -t12`) each file was left with a share of one and scanned single-threaded.

Threads follow the work: one idle on a small file checks another file's blocks. Verifying a mixed set of large and small files now takes the same time at every `-T` instead of getting steadily slower as `-T` rises, at unchanged peak memory.
